### PR TITLE
expose mirror selection to users

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -34,13 +34,19 @@ jobs:
         run: |
           make test
 
+      - name: Test jill upstream
+        run: |
+          coverage run -a -m jill upstream
+
       - name: Test jill update
         run: |
           coverage run -a -m jill update
+          coverage run -a -m jill update --upstream Official
 
       - name: Test jill mirror
         run: |
           coverage run -a -m jill mirror --config test_mirror.json
+          coverage run -a -m jill mirror --config test_mirror.json --upstream Official
           find . -type f -size +20M -name "julia-*"
           [[ `find . -type f -size +20M -name "julia-*" | wc -l` == 2 ]]
 

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
-JULIA_VERSIONS = "" "1" "1.0" "1.0.5" "1.1" "1.2" "1.3" "latest"
+JULIA_VERSIONS = "1" "1.0" "1.1" "1.2" "1.3" "latest"
 unittest:
 	python -m unittest jill/tests/tests_filters.py
 
 download_install_test:
+	coverage run -a -m jill download --upstream Official
+	coverage run -a -m jill install --upstream Official --confirm
+
 	for julia_version in $(JULIA_VERSIONS) ; do \
 		echo "Test Julia version:" $$julia_version ; \
 		coverage run -a -m jill download $$julia_version ; \
 		coverage run -a -m jill install $$julia_version --confirm ; \
 	done
+
 	# check if symlinks are created successfully
-	bash installtest.sh 1.0.0
+	bash installtest.sh 1.0.5
 	find . -type f -size +20M -name "julia-*" -delete ; \
 
 test:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Note that `Python >= 3.6` is required.
     - latest stable release for current system: `jill download`
     - latest `1.y` version: `jill download 1`
     - latest `1.3.z` version: `jill download 1.3`
+    - from specific upstream: `jill download --upstream Official`
     - specific release version: `jill download --version 1.3.0`
     - specific system: `jill download --sys freebsd`
     - specific architecture: `jill download --arch i686`
@@ -35,10 +36,12 @@ Note that `Python >= 3.6` is required.
     - only for current user: `jill install` (make symlink in `~/.local/bin`)
     - don't need interactive promopt: `jill install --confirm`
 * check if there're new Julia versions: `jill update`
+* find out all registered upstreams: `jill upstream`
+* check the not-so-elaborative documentation: `jill [COMMAND] -h` (e.g., `jill download -h`)
 
-## Mirror
+## Mirror 🚧
 
-`jill mirror` downloads all Julia releases into `./julia_pkg`
+`jill mirror [outdir]` downloads all Julia releases into `outdir`(default `./julia_pkg`)
 
 You can create a `mirror.json` in current folder to override the default mirror
 behaviors. The [mirror configuration example](mirror.example.json) shows all possible
@@ -46,11 +49,24 @@ configurable items, where only `version` is required.
 
 ## Register new mirror
 
-add an entry to `jill/config/sources.json`:
+If it's an public mirror and you want to share it worldwide. You can add an entry to the
+[public registry](jill/config/sources.json), make a PR, then I will tag a new release for that.
+
+If it's an internal mirror and you don't plan to make it public, you can create a config
+file at `~/.config/jill/sources.json` locally. The contents will be appended to
+the public registry and overwrite already existing items if there are.
+
+In the registry config file, a new mirror is a dictionary in the `upstream` field:
 
 * `name`: a distinguishable mirror name
-* `url`: URL template to retrive Julia release
-* `filename` (optional): filename template. The default value is `julia-$patch_version-$osarch.$extension`
+* `urls`: URL template to retrive Julia release
+* `latest_urls`: URL template to retrive the nightly build of Julia release
+
+## Placeholders
+
+Placeholders are used to register new mirrors. For example, the stable release url of
+the "Official" release server owned by [JuliaComputing](https://juliacomputing.com) is
+`"https://julialang2.s3.amazonaws.com/bin/$sys/$arch/$minor_version/$filename"`
 
 There're several predefined placeholders for various systems and architectures:
 
@@ -60,6 +76,7 @@ There're several predefined placeholders for various systems and architectures:
 * `architecture`: `x86_64`, `i686`, `ARMv7`, `ARMv8`
 * `arch`: `x86`, `x64`, `armv7l`, `aarch64`
 * `osarch`: `win32`, `win64`, `mac64`, `linux-armv7l`, `linux-aarch64`
+* `osbit`: `win32`, `win64`, `linux32`, `linux64`, `linuxaarch64`
 * `bit`: `32`, `64`
 * `extension`: `exe`, `tar.gz`, `dmg` (no leading `.`)
 
@@ -72,3 +89,8 @@ There're also placeholders for versions:
 * `vpatch_version`: `v1.2.3`, `latest`
 * `vminor_version`: `v1.2`, `latest`
 * `vmajor_version`: `v1`, `latest`
+
+To keep consistent names with official releases, you can use predefined name placeholders:
+
+* stable release `filename`: `julia-$patch_version-$osarch.$extension`
+* nightly release `latest_filename`: `"julia-latest-$osbit.$extension"`

--- a/jill/__main__.py
+++ b/jill/__main__.py
@@ -2,6 +2,7 @@ from .download import download_package
 from .install import install_julia
 from .mirror import mirror
 from .version_utils import update_releases
+from .source import show_upstream
 import fire
 import logging
 import os
@@ -22,7 +23,8 @@ def main():
         'download': download_package,
         'install': install_julia,
         'mirror': mirror,
-        'update': update_releases
+        'update': update_releases,
+        'upstream': show_upstream
     }, name="jill")
 
 

--- a/jill/config/sources.json
+++ b/jill/config/sources.json
@@ -1,12 +1,31 @@
 {
-    "upstream": [
-        {
-            "name": "University of Science and Technology of China",
-            "url": "https://mirrors.ustc.edu.cn/julia/releases/$vminor_version/$filename"
+    "upstream": {
+        "Official": {
+            "name": "Julia Computing, Inc.",
+            "urls": [
+                "https://julialang2.s3.amazonaws.com/bin/$sys/$arch/$minor_version/$filename"
+            ],
+            "latest_urls": [
+                "https://julialangnightlies.s3.amazonaws.com/bin/$sys/$arch/$latest_filename"
+            ]
         },
-        {
+        "USTC": {
+            "name": "University of Science and Technology of China",
+            "urls": [
+                "https://mirrors.ustc.edu.cn/julia/releases/$vminor_version/$filename"
+            ],
+            "latest_urls": [
+                "https://mirrors.ustc.edu.cn/julia/releases/latest/$latest_filename"
+            ]
+        },
+        "ZJU": {
             "name": "Zhejiang University",
-            "url": "https://mirrors.zju.edu.cn/julia/releases/$vminor_version/$filename"
+            "urls": [
+                "https://mirrors.zju.edu.cn/julia/releases/$vminor_version/$filename"
+            ],
+            "latest_urls": [
+                "https://mirrors.zju.edu.cn/julia/releases/latest/$latest_filename"
+            ]
         }
-    ]
+    }
 }

--- a/jill/defaults.py
+++ b/jill/defaults.py
@@ -6,7 +6,7 @@ MIRROR_CONFIGFILE = os.path.join(PKG_ROOT, "config", "mirror.json")
 RELEASE_CONFIGFILE = os.path.join(PKG_ROOT, "config", "releases.csv")
 
 default_filename_template = "julia-$patch_version-$osarch.$extension"
-default_latest_filename_template = "julia-latest-$os$bit.$extension"
+default_latest_filename_template = "julia-latest-$osbit.$extension"
 
 # for mirror usage: where releases are downloaded to
 default_path_template = "releases/$sys/$arch/$minor_version/$filename"

--- a/jill/defaults.py
+++ b/jill/defaults.py
@@ -1,9 +1,31 @@
+from .sys_utils import current_system
 import os
 
 PKG_ROOT = os.path.abspath(os.path.dirname(__file__))
-SOURCE_CONFIGFILE = os.path.join(PKG_ROOT, "config", "sources.json")
+
+
+def get_configfiles(filename):
+    """generate a list of config files ordered with their priorities"""
+    configfile_list = []
+    sys = current_system()
+    if sys in ["macos", "freebsd", "linux"]:
+        configfile_list.append(
+            os.path.join(os.path.expanduser("~"),
+                         ".config", "jill", filename)
+        )
+    elif sys == "windows":
+        # TODO: add user config file for windows
+        pass
+
+    # fallback config
+    configfile_list.append(os.path.join(PKG_ROOT, "config", filename))
+    return configfile_list
+
+
+SOURCE_CONFIGFILE = get_configfiles("sources.json")
 MIRROR_CONFIGFILE = os.path.join(PKG_ROOT, "config", "mirror.json")
 RELEASE_CONFIGFILE = os.path.join(PKG_ROOT, "config", "releases.csv")
+
 
 default_filename_template = "julia-$patch_version-$osarch.$extension"
 default_latest_filename_template = "julia-latest-$osbit.$extension"

--- a/jill/defaults.py
+++ b/jill/defaults.py
@@ -5,14 +5,6 @@ SOURCE_CONFIGFILE = os.path.join(PKG_ROOT, "config", "sources.json")
 MIRROR_CONFIGFILE = os.path.join(PKG_ROOT, "config", "mirror.json")
 RELEASE_CONFIGFILE = os.path.join(PKG_ROOT, "config", "releases.csv")
 
-# upstream url
-fb_prefix = 'https://julialang-s3.julialang.org/bin/'
-fb_nightly_prefix = 'https://julialangnightlies-s3.julialang.org/bin/'
-fb_nightly_url_template = fb_nightly_prefix + '$sys/$arch/$filename'
-fb_release_url_template = fb_prefix + '$sys/$arch/$minor_version/$filename'
-fb_md5_template = fb_prefix + 'checksums/julia-$patch_version.md5'
-fb_sha256_template = fb_prefix + 'julia-$patch_version.sha256'
-
 default_filename_template = "julia-$patch_version-$osarch.$extension"
 default_latest_filename_template = "julia-latest-$os$bit.$extension"
 

--- a/jill/download.py
+++ b/jill/download.py
@@ -1,4 +1,4 @@
-from .source import query_download_url
+from .source import SourceRegistry
 from .version_utils import latest_version
 from .sys_utils import current_system, current_architecture
 
@@ -38,8 +38,11 @@ def _download_package(url: str, out: str):
     return outpath
 
 
-def download_package(version=None, sys=None, arch=None,
-                     outdir=None, overwrite=False, max_try=3):
+def download_package(version=None, sys=None, arch=None, *,
+                     upstream=None,
+                     outdir=None,
+                     overwrite=False,
+                     max_try=3):
     """
     download julia release from nearest servers
 
@@ -48,6 +51,9 @@ def download_package(version=None, sys=None, arch=None,
       By default it's the latest stable release. See also `jill update`
       sys: Options are: "linux", "macos", "freebsd", "windows"
       arch: Options are: "i686", "x86_64", "ARMv7", "ARMv8"
+      upstream:
+        manually choose a download upstream. For example, set it to "Official"
+        if you want to download from JuliaComputing's s3 buckets.
       outdir: where release is downloaded to. By default it's current folder.
       overwrite: True to overwrite existing releases. By default it's False.
       max_try: try `max_try` times before returning a False.
@@ -56,11 +62,12 @@ def download_package(version=None, sys=None, arch=None,
     system = sys if sys else current_system()
     architecture = arch if arch else current_architecture()
 
-    logging.info("parse version info, it might take a while")
     version = latest_version(version, system, architecture)
     logging.info(f"download Julia release: {version}-{system}-{architecture}")
 
-    url = query_download_url(version, system, architecture, max_try=max_try)
+    registry = SourceRegistry(upstream=upstream)
+    url = registry.query_download_url(version, system, architecture,
+                                      max_try=max_try)
     if not url:
         msg = "failed to find available upstream for"
         msg += f" {version}-{system}-{architecture}"

--- a/jill/filters.py
+++ b/jill/filters.py
@@ -28,6 +28,17 @@ rules_osarch = {
     "linux-ARMv7": "linux-armv7l",
     "linux-ARMv8": "linux-aarch64"
 }
+rules_osbit = {
+    "wini686": "win32",
+    "winx86_64": "win64",
+    "macx86_64": "mac64",
+    "linuxARMv7": "linuxarmv7l",
+    "linuxARMv8": "linuxaarch64",
+    "linuxx86_64": "linux64",
+    "linuxi686": "linux32",
+    "freebsdx86_64": "freebsd64",
+    "freebsdi686": "freebsd32"
+}
 rules_extension = {
     "windows": "exe",
     "linux": "tar.gz",
@@ -204,6 +215,11 @@ def _OSarch(os, arch):
 f_Osarch = NameFilter(_Osarch)
 f_OSarch = NameFilter(_OSarch)
 
+f_osbit = NameFilter(f=lambda os, arch: f"{os}{arch}",
+                     rules=rules_osbit,
+                     validate=lambda os, arch:
+                     is_os(os) and is_architecture(arch))
+
 f_bit = NameFilter(rules=rules_bit, validate=is_architecture)
 
 f_extension = NameFilter(rules=rules_extension, validate=is_system)
@@ -259,6 +275,8 @@ def generate_info(plain_version: str,
         "osarch": f_osarch(os, architecture),
         "Osarch": f_Osarch(os, architecture),
         "OSarch": f_OSarch(os, architecture),
+
+        "osbit": f_osbit(os, architecture),
 
         "bit": f_bit(architecture),
         "extension": f_extension(system),

--- a/jill/install.py
+++ b/jill/install.py
@@ -90,7 +90,10 @@ def install_julia_mac(package_path, install_dir, symlink_dir, version):
     return True
 
 
-def install_julia(version=None, install_dir=None, symlink_dir=None,
+def install_julia(version=None, *,
+                  install_dir=None,
+                  symlink_dir=None,
+                  upstream=None,
                   confirm=False):
     """
     Install julia for Linux and MacOS
@@ -98,6 +101,9 @@ def install_julia(version=None, install_dir=None, symlink_dir=None,
     Arguments:
       version: Option examples: 1, 1.2, 1.2.3, latest.
       By default it's the latest stable release. See also `jill update`
+      upstream:
+        manually choose a download upstream. For example, set it to "Official"
+        if you want to download from JuliaComputing's s3 buckets.
       confirm: add `--confirm` to skip interactive prompt.
     """
     install_dir = install_dir if install_dir else default_install_dir()
@@ -118,7 +124,10 @@ def install_julia(version=None, install_dir=None, symlink_dir=None,
         if not to_continue:
             return False
 
-    package_path = download_package(version, system, arch)
+    overwrite = True if version == "latest" else False
+    package_path = download_package(version, system, arch,
+                                    upstream=upstream,
+                                    overwrite=overwrite)
     if not package_path:
         return False
 

--- a/jill/mirror.py
+++ b/jill/mirror.py
@@ -101,7 +101,8 @@ class Mirror:
         self.config = config
         self.failed_releases = self.config.releases
 
-    def pull_releases(self):
+    def pull_releases(self, *,
+                      upstream=None):
         failed_releases = self.failed_releases.copy()
         for item in self.failed_releases:
             filepath = self.config.get_outpath(*item)
@@ -110,16 +111,20 @@ class Mirror:
 
             logging.info(f"start to pull {filepath}")
             overwrite = True if item[0] == "latest" else self.config.overwrite
-            rst = download_package(*item, outdir, overwrite)
-            assert os.path.exists(outpath)
+            rst = download_package(*item,
+                                   outdir=outdir,
+                                   upstream=upstream,
+                                   overwrite=overwrite)
             if rst:
+                assert os.path.exists(outpath)
                 assert item in self.failed_releases
                 failed_releases.remove(item)
         self.failed_releases = failed_releases
 
 
-def mirror(period=0,
-           outdir="julia_pkg",
+def mirror(outdir="julia_pkg", *,
+           period=0,
+           upstream=None,
            logfile="mirror.log",
            config="mirror.json"):
     """
@@ -140,7 +145,7 @@ def mirror(period=0,
     m.config.logging()
     while True:
         logging.info("START: pull Julia releases")
-        m.pull_releases()
+        m.pull_releases(upstream=upstream)
         logging.info("END: pulling Julia releases")
 
         if period == 0:

--- a/jill/source.py
+++ b/jill/source.py
@@ -150,8 +150,8 @@ class SourceRegistry:
     def info(self):
         msg = f"found {len(self)} release sources:\n"
         for src in self.registry.keys():
-            msg += "    - " + str(src)
-        logging.info(msg)
+            msg += "  - " + str(src) + "\n"
+        return msg
 
     def _get_urls(self, plain_version, system, architecture):
         """
@@ -179,3 +179,9 @@ class SourceRegistry:
             if is_url_available(url, timeout):
                 return url
         return None
+
+
+def show_upstream():
+    """print all registered upstream servers"""
+    registry = SourceRegistry()
+    print(registry.info())

--- a/jill/sys_utils.py
+++ b/jill/sys_utils.py
@@ -1,14 +1,18 @@
-import sys
 import platform
 
 
 def current_system():
-    if sys.platform == "linux" or sys.platform == "linux2":
+    rst = platform.system()
+    if rst == "Linux":
         return "linux"
-    elif sys.platform == "darwin":
+    elif rst == "Darwin":
         return "macos"
-    elif sys.platform == "win32" or sys.platform == "win64":
+    elif rst == "FreeBSD":
+        return "freebsd"
+    elif rst == "Windows":
         return "windows"
+    else:
+        raise ValueError(f"Unsupported system {rst}")
 
 
 def current_architecture():

--- a/jill/tests/tests_filters.py
+++ b/jill/tests/tests_filters.py
@@ -7,8 +7,10 @@ from jill.filters import f_sys, f_Sys, f_SYS
 from jill.filters import f_os, f_Os, f_OS
 from jill.filters import f_arch, f_Arch, f_ARCH
 from jill.filters import f_osarch, f_Osarch, f_OSarch
+from jill.filters import f_osbit
 from jill.filters import f_bit
 from jill.filters import f_extension
+from jill.filters import generate_info
 import unittest
 
 
@@ -170,6 +172,17 @@ class TestFilters(unittest.TestCase):
         self.assertEqual(f_OSarch("linux", "x86_64"), "LINUX-x86_64")
         self.assertEqual(f_OSarch("freebsd", "x86_64"), "FREEBSD-x86_64")
 
+    def test_osbit(self):
+        self.assertEqual(f_osbit("win", "i686"), "win32")
+        self.assertEqual(f_osbit("win", "x86_64"), "win64")
+        self.assertEqual(f_osbit("mac", "x86_64"), "mac64")
+        self.assertEqual(f_osbit("linux", "ARMv7"), "linuxarmv7l")
+        self.assertEqual(f_osbit("linux", "ARMv8"), "linuxaarch64")
+        self.assertEqual(f_osbit("linux", "i686"), "linux32")
+        self.assertEqual(f_osbit("linux", "x86_64"), "linux64")
+        self.assertEqual(f_osbit("freebsd", "x86_64"), "freebsd64")
+        self.assertEqual(f_osbit("freebsd", "i686"), "freebsd32")
+
     def test_bit(self):
         self.assertEqual(f_bit("i686"), 32)
         self.assertEqual(f_bit("x86_64"), 64)
@@ -181,3 +194,55 @@ class TestFilters(unittest.TestCase):
         self.assertEqual(f_extension("macos"), "dmg")
         self.assertEqual(f_extension("freebsd"), "tar.gz")
         self.assertEqual(f_extension("windows"), "exe")
+
+    def test_latest_filename(self):
+        info = generate_info("latest", "linux", "i686")
+        self.assertEqual(info["latest_filename"],
+                         "julia-latest-linux32.tar.gz")
+        info = generate_info("latest", "linux", "x86_64")
+        self.assertEqual(info["latest_filename"],
+                         "julia-latest-linux64.tar.gz")
+
+        info = generate_info("latest", "linux", "ARMv8")
+        self.assertEqual(info["latest_filename"],
+                         "julia-latest-linuxaarch64.tar.gz")
+
+        info = generate_info("latest", "windows", "i686")
+        self.assertEqual(info["latest_filename"],
+                         "julia-latest-win32.exe")
+        info = generate_info("latest", "windows", "x86_64")
+        self.assertEqual(info["latest_filename"],
+                         "julia-latest-win64.exe")
+
+        info = generate_info("latest", "macos", "x86_64")
+        self.assertEqual(info["latest_filename"],
+                         "julia-latest-mac64.dmg")
+
+    def test_filename(self):
+        info = generate_info("1.3.0", "linux", "i686")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-linux-i686.tar.gz")
+        info = generate_info("1.3.0", "linux", "x86_64")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-linux-x86_64.tar.gz")
+        info = generate_info("1.3.0", "linux", "ARMv7")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-linux-armv7l.tar.gz")
+        info = generate_info("1.3.0", "linux", "ARMv8")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-linux-aarch64.tar.gz")
+
+        info = generate_info("1.3.0", "windows", "i686")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-win32.exe")
+        info = generate_info("1.3.0", "windows", "x86_64")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-win64.exe")
+
+        info = generate_info("1.3.0", "macos", "x86_64")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-mac64.dmg")
+
+        info = generate_info("1.3.0", "freebsd", "x86_64")
+        self.assertEqual(info["filename"],
+                         "julia-1.3.0-freebsd-x86_64.tar.gz")


### PR DESCRIPTION
although it's nice to automatically download releases from *nearest* servers, there're cases where users only want to download Julia from a certain source. For example:

* Only download and install from official s3 bucket
* sources that are known to have stable connection status
* internal mirror server which is not contained in `config/sources.json`

The usage should be like

`jill download 1.3.0 --source Official`

a possible roadmap:

- [x] introduce `SourceRegistry`
- [x] accept a custom `sources.json`
- [x] expose a `source` parameter from `download`, `install`, `mirror` and `update`


---

This also fix a filter mistake: the latest_filename of `latest-linux-ARMv8` should be `julia-latest-linuxaarch64.tar.gz` instead of `julia-latest-linux64.tar.gz`, which belongs to that of `latest-linux-x86_64`