### PR TITLE
[WIP] package mirror

### DIFF
--- a/jill/__init__.py
+++ b/jill/__init__.py
@@ -1,7 +1,0 @@
-from .download import download_package
-from .mirror import Mirror, MirrorConfig
-
-__all__ = [
-    "download_package",
-    "Mirror", "MirrorConfig"
-]

--- a/mirror.example.json
+++ b/mirror.example.json
@@ -1,7 +1,9 @@
 {
-    "filename": "julia-$patch_version-$osarch.$extension",
-    "latest_filename": "julia-latest-$osbit.$extension",
-    "path": "releases/$vminor_version/$filename",
-    "overwrite": "False",
-    "require_latest": "True"
+    "release": {
+        "filename": "julia-$patch_version-$osarch.$extension",
+        "latest_filename": "julia-latest-$osbit.$extension",
+        "path": "releases/$vminor_version/$filename",
+        "overwrite": "False",
+        "require_latest": "True"
+    }
 }


### PR DESCRIPTION
closes #10 

To take advantage of the [PkgServer](https://github.com/JuliaPackaging/PkgServer.jl) feature of Julia v1.4 and make static file mirror set up easily. (Well, just need to make a fork of [gen_static.jl](https://github.com/JuliaPackaging/PkgServer.jl/blob/ef6ac5f4027e8d89bb4239d32cb430d92907a795/bin/gen_static.jl))

TODO:

- [ ] general registry
- [ ] package
- [ ] artifacts