### PR TITLE
add one more server for official

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -29,9 +29,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install coverage
+          python -m pip install --upgrade pip --quiet
+          pip install -r requirements.txt --quiet
+          pip install coverage --quiet
 
       - name: Test jill download and install
         run: |
@@ -75,12 +75,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install coverage
+          python -m pip install --upgrade pip --quiet
+          pip install -r requirements.txt --quiet
+          pip install coverage --quiet
 
       - name: test install
         run: |
+          python -m jill upstream
           python -m jill install --confirm --upstream Official
           & julia -e 'using InteractiveUtils; versioninfo()'
           & julia --project=. -e 'using Pkg; Pkg.add(\"ImageCore\")'
@@ -116,8 +117,9 @@ jobs:
         run: |
           apt-get update -qq
           apt-get install -y -qq -o=Dpkg::Use-Pty=0 python3-pip python3-wheel python3-setuptools gnupg wget --no-install-recommends
-          pip3 install --upgrade pip
-          pip3 install -r requirements.txt
+          pip3 install --upgrade pip --quiet
+          pip3 install -r requirements.txt --quiet
+          python -m jill upstream
           python3 -m jill install --confirm --upstream Official
           julia -e 'using InteractiveUtils; versioninfo()'
           python3 -m jill install 1.0 --confirm --upstream Official

--- a/jill/config/sources.json
+++ b/jill/config/sources.json
@@ -3,10 +3,16 @@
         "Official": {
             "name": "Julialang.org",
             "urls": [
-                "https://julialang-s3.julialang.org/bin/$sys/$arch/$minor_version/$filename"
+                "https://julialang-s3.julialang.org/bin/$sys/$arch/$minor_version/$filename",
+                "https://mirror.kr.pkg.julialang.org/julialang2/bin/$sys/$arch/$minor_version/$filename",
+                "https://mirror.eu.pkg.julialang.org/julialang2/bin/$sys/$arch/$minor_version/$filename",
+                "https://mirror.us-east.pkg.julialang.org/julialang2/bin/$sys/$arch/$minor_version/$filename"
             ],
             "latest_urls": [
-                "https://julialangnightlies-s3.julialang.org/bin/$sys/$arch/$latest_filename"
+                "https://julialangnightlies-s3.julialang.org/bin/$sys/$arch/$latest_filename",
+                "https://mirror.kr.pkg.julialang.org/julialangnightlies/bin/$sys/$arch/$latest_filename",
+                "https://mirror.eu.pkg.julialang.org/julialangnightlies/bin/$sys/$arch/$latest_filename",
+                "https://mirror.us-east.pkg.julialang.org/julialangnightlies/bin/$sys/$arch/$latest_filename"
             ]
         },
         "USTC": {

--- a/jill/utils/source_utils.py
+++ b/jill/utils/source_utils.py
@@ -7,6 +7,7 @@ from .defaults import SOURCE_CONFIGFILE
 from .net_utils import query_ip
 from .net_utils import port_response_time
 from .net_utils import is_url_available
+from .sys_utils import show_verbose
 from .filters import generate_info
 from .interactive_utils import color
 
@@ -198,6 +199,8 @@ class SourceRegistry:
 
         url_list = chain.from_iterable(repeat(url_list, max_try))
         for url in url_list:
+            if show_verbose():
+                print(f"query {url}")
             if is_url_available(url, timeout):
                 return url
         return None

--- a/jill/utils/sys_utils.py
+++ b/jill/utils/sys_utils.py
@@ -3,6 +3,7 @@ tools to detect current system and architecture so that things work with tools
 in the `filters` module
 """
 import platform
+import os
 
 
 def current_system():
@@ -31,3 +32,10 @@ def current_architecture():
         return "x86_64"
     else:
         return arch
+
+
+def show_verbose():
+    if "GITHUB_ACTIONS" in os.environ:
+        return True
+
+    return os.environ.get("DEBUG", False)


### PR DESCRIPTION
```
» python -m jill upstream
Found 4 release sources:

- Official: Julialang.org
  * julialang-s3.julialang.org (245 ms)
  * mirror.kr.pkg.julialang.org (154 ms)
  * mirror.eu.pkg.julialang.org (308 ms)
  * mirror.us-east.pkg.julialang.org (270 ms)
  * julialangnightlies-s3.julialang.org (245 ms)
- USTC: University of Science and Technology of China
  * mirrors.ustc.edu.cn (11 ms)
- ZJU: Zhejiang University
  * mirrors.zju.edu.cn (7 ms)
- LFLab: LFLab, ECNU Math
  * mirrors.lflab.cn (0 ms)
```