### PR TITLE
loose error handling for invalid symlink

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -34,7 +34,10 @@ jobs:
           pip install coverage --quiet
 
       - name: Test jill download and install
+        # make an invalid symlink before installation
+        # issue: https://github.com/abelsiqueira/jill/issues/25
         run: |
+          mkdir ~/.local/bin -p && ln -sf /abcde ~/.local/bin/julia
           make test
 
       - name: Test jill upstream

--- a/jill/install.py
+++ b/jill/install.py
@@ -51,9 +51,9 @@ def get_exec_version(path):
         # outputs: "julia version 1.4.0-rc1"
         version = subprocess.check_output(ver_cmd).decode("utf-8")
         version = version.lower().split("version")[-1].strip()
-    except subprocess.CalledProcessError as e:
-        # in case it's not executable
-        logging.warn(e)
+    except: # nopep8
+        # in case it fails in any situation: invalid target or command(.cmd)
+        # issue: https://github.com/abelsiqueira/jill/issues/25
         version = "0.0.1"
     return version
 


### PR DESCRIPTION
The strategy is to remove the symlink/cmd for whatever reason it doesn't return a valid Julia version.