### PR TITLE
remove "slow" sources that has low latency

### DIFF
--- a/jill/config/releases.csv
+++ b/jill/config/releases.csv
@@ -11,6 +11,7 @@
 1.3.1,freebsd,x86_64
 1.4.0,freebsd,x86_64
 1.4.1,freebsd,x86_64
+1.4.2,freebsd,x86_64
 latest,freebsd,x86_64
 1.0.0,linux,ARMv7
 1.0.3,linux,ARMv7
@@ -59,6 +60,7 @@ latest,linux,i686
 1.3.1,linux,x86_64
 1.4.0,linux,x86_64
 1.4.1,linux,x86_64
+1.4.2,linux,x86_64
 latest,linux,x86_64
 1.0.0,macos,x86_64
 1.0.1,macos,x86_64
@@ -72,6 +74,8 @@ latest,linux,x86_64
 1.3.0,macos,x86_64
 1.3.1,macos,x86_64
 1.4.0,macos,x86_64
+1.4.1,macos,x86_64
+1.4.2,macos,x86_64
 latest,macos,x86_64
 1.0.0,windows,i686
 1.0.1,windows,i686
@@ -101,4 +105,3 @@ latest,windows,i686
 1.4.0,windows,x86_64
 1.4.1,windows,x86_64
 latest,windows,x86_64
-1.4.1,macos,x86_64

--- a/jill/config/sources.json
+++ b/jill/config/sources.json
@@ -3,16 +3,10 @@
         "Official": {
             "name": "Julialang.org",
             "urls": [
-                "https://julialang-s3.julialang.org/bin/$sys/$arch/$minor_version/$filename",
-                "https://mirror.kr.pkg.julialang.org/julialang2/bin/$sys/$arch/$minor_version/$filename",
-                "https://mirror.eu.pkg.julialang.org/julialang2/bin/$sys/$arch/$minor_version/$filename",
-                "https://mirror.us-east.pkg.julialang.org/julialang2/bin/$sys/$arch/$minor_version/$filename"
+                "https://julialang-s3.julialang.org/bin/$sys/$arch/$minor_version/$filename"
             ],
             "latest_urls": [
-                "https://julialangnightlies-s3.julialang.org/bin/$sys/$arch/$latest_filename",
-                "https://mirror.kr.pkg.julialang.org/julialangnightlies/bin/$sys/$arch/$latest_filename",
-                "https://mirror.eu.pkg.julialang.org/julialangnightlies/bin/$sys/$arch/$latest_filename",
-                "https://mirror.us-east.pkg.julialang.org/julialangnightlies/bin/$sys/$arch/$latest_filename"
+                "https://julialangnightlies-s3.julialang.org/bin/$sys/$arch/$latest_filename"
             ]
         },
         "USTC": {

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io_open(requirements, mode='r') as fd:
 
 setuptools.setup(
     name='jill',
-    version='0.6.8',
+    version='0.6.9',
     author="Johnny Chen",
     author_email="johnnychen94@hotmail.com",
     description="JILL -- Julia Installer for Linux (MacOS, Windows and FreeBSD) -- Light",


### PR DESCRIPTION
The upstreams are sorted by latencies, but I've personally never experienced a case that downloading Julia releases from `mirror.<code>.pkg.julialang.org` becoming faster than `julialang-s3.julialang.org`. In my case `mirror.kr.pkg.julialang.org` is often 10-50x slower than `julialang-s3.julialang.org` -- `30m` vs `30s`.

For this very personal reason, I removed these sources so that users in China (mostly it's me 😄 ) don't "accidentally" download Julia releases from s3 mirrors.

For example, according to the `jill upstream` result, it would download julia release from `mirror.<code>.pkg.julialang.org` instead of from the faster `julialang-s3.julialang.org` or USTC/ZJU mirror.

```text
$jill upstream

Found 4 release sources:

- Official: Julialang.org
  * julialang-s3.julialang.org (8 ms)
  * mirror.kr.pkg.julialang.org (2 ms)
  * mirror.eu.pkg.julialang.org (2 ms)
  * mirror.us-east.pkg.julialang.org (2 ms)
  * julialangnightlies-s3.julialang.org (8 ms)
- USTC: University of Science and Technology of China
  * mirrors.ustc.edu.cn (50 ms)
- ZJU: Zhejiang University
  * mirrors.zju.edu.cn (32 ms)
- LFLab: LFLab in ECNU Math
  * mirrors.lflab.cn (2000 ms)
```
