### PR TITLE
send concurrent HEAD requests

### DIFF
--- a/jill/download.py
+++ b/jill/download.py
@@ -50,8 +50,7 @@ def _download(url: str, out: str):
 def download_package(version=None, sys=None, arch=None, *,
                      upstream=None,
                      outdir=None,
-                     overwrite=False,
-                     max_try=3):
+                     overwrite=False):
     """
     download julia release from nearest servers
 
@@ -97,8 +96,6 @@ def download_package(version=None, sys=None, arch=None, *,
         where release is downloaded to. By default it's the current folder.
       overwrite:
         add `--overwrite` flag to overwrite existing releases.
-      max_try:
-        try `max_try` times before returning a False. The default value is 3.
     """
     version = str(version) if (version or str(version) == "0") else ""
     version = "latest" if version == "nightly" else version
@@ -141,8 +138,7 @@ def download_package(version=None, sys=None, arch=None, *,
     logging.info(msg)
     print(msg)
     registry = SourceRegistry(upstream=upstream)
-    url = registry.query_download_url(version, system, architecture,
-                                      max_try=max_try)
+    url = registry.query_download_url(version, system, architecture)
     if not url:
         msg = f"failed to find available upstream for {release_str}"
         logging.warning(msg)

--- a/jill/utils/source_utils.py
+++ b/jill/utils/source_utils.py
@@ -6,7 +6,7 @@ from .defaults import default_scheme_ports
 from .defaults import SOURCE_CONFIGFILE
 from .net_utils import query_ip
 from .net_utils import port_response_time
-from .net_utils import is_url_available
+from .net_utils import first_response
 from .sys_utils import show_verbose
 from .filters import generate_info
 from .interactive_utils import color
@@ -15,13 +15,10 @@ from itertools import chain, repeat
 from urllib.parse import urlparse
 from string import Template
 
-import requests
 import json
 import os
 
 from typing import List
-
-from requests.exceptions import RequestException
 
 
 class ReleaseSource:
@@ -191,20 +188,13 @@ class SourceRegistry:
 
     def query_download_url(self,
                            version, system, arch, *,
-                           max_try=3, timeout=10):
+                           timeout=3):
         """
         return a valid download url to nearest mirror server. If there isn't
         such version then return None.
         """
         url_list = self._get_urls(version, system, arch)
-
-        url_list = chain.from_iterable(repeat(url_list, max_try))
-        for url in url_list:
-            if show_verbose():
-                print(f"query {url}")
-            if is_url_available(url, timeout):
-                return url
-        return None
+        return first_response(url_list, timeout=timeout)
 
 
 def show_upstream():

--- a/jill/utils/version_utils.py
+++ b/jill/utils/version_utils.py
@@ -90,7 +90,7 @@ def read_releases(stable_only=False) -> List[Tuple]:
 def is_version_released(version, system, architecture,
                         update=False,
                         upstream=None,
-                        timeout=5,
+                        timeout=2,
                         cache=dict()):
     if not is_valid_release(version, system, architecture):
         return False
@@ -108,8 +108,7 @@ def is_version_released(version, system, architecture,
         # query process is time-consuming
         registry = SourceRegistry(upstream=upstream)
         rst = bool(registry.query_download_url(*item,
-                                               timeout=timeout,
-                                               max_try=1))
+                                               timeout=timeout))
         if show_verbose():
             c = color.GREEN if rst else color.RED
             msg = f"{c}{item}={rst}{color.END}"
@@ -270,7 +269,7 @@ def sort_releases():
 
 def update_releases(system=None, architecture=None, *,
                     upstream="Official",
-                    timeout=5):
+                    timeout=2):
     """
     check if there're new Julia releases
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 fire
 semantic_version
 python-gnupg
+requests_futures


### PR DESCRIPTION
fixes #35 fixes #14 

Now jill sends multiple HEAD requests concurrently to verify if upstreams have resources. It uses an early-return method to cancel other jobs whenever we get one 200 response.

This PR also sets a smaller request timeout to additionally reduces the querying time.