### PR TITLE
skip installation if it's already available

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -88,14 +88,14 @@ jobs:
         run: |
           mkdir ~/.local/bin -p && ln -sf /abcde ~/.local/bin/julia
           python -m jill download --sys musl --upstream Official
-          python -m jill install --upstream Official --confirm
+          python -m jill install --upstream Official --confirm --reinstall
           julia -e 'using InteractiveUtils; versioninfo()'
-          python -m jill install 1 --upstream Official --confirm
+          python -m jill install 1 --upstream Official --confirm --reinstall
           julia -e 'using InteractiveUtils; versioninfo()'
           julia-1 -e 'using InteractiveUtils; versioninfo()'
-          python -m jill install 1.5 --upstream Official --confirm
+          python -m jill install 1.5 --upstream Official --confirm --reinstall
           julia -e 'using InteractiveUtils; versioninfo()'
-          julia-1.5 -e 'using InteractiveUtils; versioninfo'
+          julia-1.5 -e 'using InteractiveUtils; versioninfo()'
 
   windows_job:
     name: Unit Test
@@ -122,17 +122,17 @@ jobs:
       - name: test install
         run: |
           python -m jill upstream
-          python -m jill install --confirm --upstream Official
+          python -m jill install --confirm --upstream Official --reinstall
           & julia -e 'using InteractiveUtils; versioninfo()'
           & julia --project=. -e 'using Pkg; Pkg.add(\"ImageCore\")'
       - name: test symlink
         run: |
-          python -m jill install 1.0 --confirm --upstream Official
+          python -m jill install 1.0 --confirm --upstream Official --reinstall
           & julia -e 'using InteractiveUtils; versioninfo()'
           & julia-1.0 -e 'using InteractiveUtils; versioninfo()'
       - name: test nightly
         run: |
-          python -m jill install latest --confirm --upstream Official
+          python -m jill install latest --confirm --upstream Official --reinstall
           & julia -e 'using InteractiveUtils; versioninfo()'
           & julia-1.0 -e 'using InteractiveUtils; versioninfo()'
           & julia-latest -e 'using InteractiveUtils; versioninfo()'

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ download_install_test:
 	for julia_version in $(JULIA_VERSIONS) ; do \
 		echo "Test Julia version:" $$julia_version ; \
 		coverage run -a -m jill download $$julia_version ; \
-		coverage run -a -m jill install $$julia_version --confirm --keep_downloads ; \
+		coverage run -a -m jill install $$julia_version --confirm --keep_downloads --reinstall ; \
 		julia -e 'using InteractiveUtils; versioninfo()' ; \
 	done
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note that `Python >= 3.6` is required. For base docker images, you also need to 
 
 Basic usage:
 
-`jill install [version] [--confirm] [--upstream UPSTREAM] [--install_dir INSTALL_DIR] [--symlink_dir SYMLINK_DIR]`
+`jill install [version] [--confirm] [--upstream UPSTREAM] [--reinstall] [--install_dir INSTALL_DIR] [--symlink_dir SYMLINK_DIR]`
 
 For the first-time users of `jill.py`, you may need to modify `PATH` accordingly so that your shell can find the executables when you type `julia`.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -39,6 +39,11 @@ _跨平台的 Julia 一键安装脚本_
 
 ## 使用帮助
 
+基本使用:
+
+`jill install [version] [--confirm] [--upstream UPSTREAM] [--reinstall] [--install_dir INSTALL_DIR]
+[--symlink_dir SYMLINK_DIR]`
+
 简而言之，`jill install [version]` 能满足你绝大部分要求。对于初次使用 `jill.py` 的用户而言，你可能需要修改 `PATH`
 来让命令行正常找到 Julia.
 

--- a/jill/install.py
+++ b/jill/install.py
@@ -287,7 +287,8 @@ def install_julia(version=None, *,
                   upgrade=False,
                   upstream=None,
                   keep_downloads=False,
-                  confirm=False):
+                  confirm=False,
+                  reinstall=False):
     """
     Install the Julia programming language for your current system
 
@@ -318,6 +319,9 @@ def install_julia(version=None, *,
       keep_downloads:
         add `--keep_downloads` flag to not remove downloaded releases.
       confirm: add `--confirm` flag to skip interactive prompt.
+      reinstall:
+        jill will skip the installation if the required Julia version already exists,
+        add `--reinstall` flag to force the reinstallation.
       install_dir:
         where you want julia packages installed.
       symlink_dir:
@@ -366,7 +370,7 @@ def install_julia(version=None, *,
         msg += f"Example: `jill install 1`"
         raise(ValueError(msg))
 
-    if Version(version) == Version(get_exec_version()):
+    if not reinstall and Version(version) == Version(get_exec_version()):
         print(f"julia {version} already installed.")
         return True
 

--- a/jill/install.py
+++ b/jill/install.py
@@ -46,7 +46,9 @@ def default_install_dir():
         raise ValueError(f"Unsupported system: {system}")
 
 
-def get_exec_version(path):
+def get_exec_version(path=None):
+    if path is None:
+        path = shutil.which("julia")
     ver_cmd = [path, "--version"]
     try:
         # outputs: "julia version 1.4.0-rc1"
@@ -363,6 +365,10 @@ def install_julia(version=None, *,
         msg = f"wrong version(>= 0.6.0) argument: {version}\n"
         msg += f"Example: `jill install 1`"
         raise(ValueError(msg))
+
+    if Version(version) == Version(get_exec_version()):
+        print(f"julia {version} already installed.")
+        return True
 
     overwrite = True if version == "latest" else False
     print(f"{color.BOLD}----- Download Julia -----{color.END}")

--- a/jill/install.py
+++ b/jill/install.py
@@ -46,9 +46,24 @@ def default_install_dir():
         raise ValueError(f"Unsupported system: {system}")
 
 
-def get_exec_version(path=None):
-    if path is None:
-        path = shutil.which("julia")
+def is_installed(version, check_symlinks=True):
+    """
+        check if the required version is already installed.
+    """
+    check_list = ["julia"]
+    if version == "latest":
+        check_list.append("julia-latest")
+    if version != "latest" and check_symlinks:
+        check_list.extend([f"julia-{f_major_version(version)}",
+                           f"julia-{f_minor_version(version)}"])
+
+    for path in check_list:
+        if Version(get_exec_version(shutil.which(path))) != Version(version):
+            return False
+    return True
+
+
+def get_exec_version(path):
     ver_cmd = [path, "--version"]
     try:
         # outputs: "julia version 1.4.0-rc1"
@@ -370,7 +385,7 @@ def install_julia(version=None, *,
         msg += f"Example: `jill install 1`"
         raise(ValueError(msg))
 
-    if not reinstall and Version(version) == Version(get_exec_version()):
+    if not reinstall and is_installed(version):
         print(f"julia {version} already installed.")
         return True
 


### PR DESCRIPTION
This way `jill` will:

- skip the installation if the existing julia version equals the required version. By default, the required version is the latest stable release.

cc: @ChrisRackauckas