### PR TITLE
add opentuna mirror

### DIFF
--- a/jill/config/sources.json
+++ b/jill/config/sources.json
@@ -21,7 +21,8 @@
         "TUNA": {
             "name": "Tsinghua University TUNA Association",
             "urls": [
-                "https://mirrors.tuna.tsinghua.edu.cn/julia-releases/bin/$sys/$arch/$minor_version/$filename"
+                "https://mirrors.tuna.tsinghua.edu.cn/julia-releases/bin/$sys/$arch/$minor_version/$filename",
+                "https://opentuna.cn/julia-releases/bin/$sys/$arch/$minor_version/$filename"
             ],
             "latest_urls": [
                 ""

--- a/jill/utils/source_utils.py
+++ b/jill/utils/source_utils.py
@@ -96,7 +96,7 @@ class ReleaseSource:
         url_list = [t.substitute(**configs) for t in template_lists]
         url_list.sort(key=lambda url:
                       self.latencies[urlparse(url).netloc])
-        return url_list[0] if url_list else ""
+        return url_list if url_list else ""
 
 
 def read_registry():
@@ -179,8 +179,9 @@ class SourceRegistry:
         system and architecture. Special version name such as 'latest' are
         treated differently.
         """
-        url_list = [src.get_url(plain_version, system, architecture)
-                    for src in self.registry.values()]
+        url_list = []
+        for src in self.registry.values():
+            url_list.extend(src.get_url(plain_version, system, architecture))
         url_list = [url for url in url_list if url]
         url_list.sort(key=lambda url:
                       self.latencies[urlparse(url).netloc])


### PR DESCRIPTION
also fix a "bug" when multiple urls are provided in one mirror. This was deliberately made so because `jill` doesn't support async URL check then.