### PR TITLE
JILL_UPSTREAM environmental variable

### DIFF
--- a/jill/download.py
+++ b/jill/download.py
@@ -100,6 +100,7 @@ def download_package(version=None, sys=None, arch=None, *,
     version = str(version) if (version or str(version) == "0") else ""
     version = "latest" if version == "nightly" else version
     version = "" if version == "stable" else version
+    upstream = upstream if upstream else os.environ.get("JILL_UPSTREAM", None)
 
     system = sys if sys else current_system()
     if system == "linux" and current_system() == "linux" and current_libc() == "musl":

--- a/jill/install.py
+++ b/jill/install.py
@@ -350,6 +350,7 @@ def install_julia(version=None, *,
     version = str(version) if (version or str(version) == "0") else ''
     version = "latest" if version == "nightly" else version
     version = "" if version == "stable" else version
+    upstream = upstream if upstream else os.environ.get("JILL_UPSTREAM", None)
 
     if system == "linux" and current_libc() == "musl":
         # currently Julia tags musl as a system, e.g.,


### PR DESCRIPTION
See #60. I used
```Julia
upstream = upstream if upstream else os.environ.get("JILL_UPSTREAM", None)
```
instead of
```Julia
upstream = os.environ.get("JILL_UPSTREAM", upstream)
```
because the manual setting of `--upstream=WHATEVER` should always supersede the environmental variable.

Closes #60.