### PR TITLE
clean-up and enhancement to versions.json workflow (follow up #58)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ JULIA_VERSIONS = "1" "1.0" "1.1" "1.2" "1.3" "1.4.0-rc1" "latest"
 unittest:
 	python -m unittest jill/tests/tests_filters.py
 	python -m unittest jill/tests/tests_versions.py
+	python -m unittest jill/tests/tests_alias.py
 
 download_install_test:
 	# check if upstream works

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ For Julia (>= 1.5.0) in Linux with `musl` dependency, you can
 - download it by passing `--sys musl` command. In the meantime, `--sys linux` will give you Julia
   binaries built with `glibc` dependency.
 
+Setting environment variable `JILL_UPSTREAM` will disable the fancy "find-the-nearest-upstream"
+feature of `jill` and give you a faster download experience if you just know which upstream is the
+fastest. (It has lower priorty than `--upstream` flag.)
+
 ## Example with cron
 
 If you're tired of seeing `(xx days old master)` in your nightly build version, then `jill` can
@@ -117,52 +121,4 @@ it's released -- you don't even need to upgrade `jill`.
 
 ## For who are interested in setting up a new release mirror
 
-This section is not for common `jill.py` users that simply wants to download and install Julia.
-
-### Register new mirror
-
-If it's an public mirror and you want to share it worldwide. You can add an entry to the
-[public registry](jill/config/sources.json), make a PR, then I will tag a new release for that.
-
-If it's an internal mirror and you don't plan to make it public, you can create a config
-file at `~/.config/jill/sources.json` locally. The contents will be appended to
-the public registry and overwrite already existing items if there are.
-
-In the registry config file, a new mirror is a dictionary in the `upstream` field:
-
-* `name`: a distinguishable mirror name
-* `urls`: URL template to retrive Julia release
-* `latest_urls`: URL template to retrive the nightly build of Julia release
-
-### Placeholders
-
-Placeholders are used to register new mirrors. For example, the stable release url of
-the "Official" release server provided by [Julialang.org](https://julialang.org/) is
-`"https://julialang-s3.julialang.org/bin/$sys/$arch/$minor_version/$filename"`
-
-There're several predefined placeholders for various systems and architectures:
-
-* `system`: `windows`, `macos`, `linux`, `freebsd`
-* `sys`: `winnt`, `mac`, `linux`, `freebsd`
-* `os`: `win`, `mac`, `linux`, `freebsd`
-* `architecture`: `x86_64`, `i686`, `ARMv7`, `ARMv8`
-* `arch`: `x86`, `x64`, `armv7l`, `aarch64`
-* `osarch`: `win32`, `win64`, `mac64`, `linux-armv7l`, `linux-aarch64`
-* `osbit`: `win32`, `win64`, `linux32`, `linux64`, `linuxaarch64`
-* `bit`: `32`, `64`
-* `extension`: `exe`, `tar.gz`, `dmg` (no leading `.`)
-
-There're also placeholders for versions:
-
-* `patch_version`: `1.2.3`, `latest`
-* `minor_version`: `1.2`, `latest`
-* `major_version`: `1`
-* `version`: `1.2.3-pre`, `latest` (no leading `v`)
-* `vpatch_version`: `v1.2.3`, `latest`
-* `vminor_version`: `v1.2`, `latest`
-* `vmajor_version`: `v1`, `latest`
-
-To keep consistent names with official releases, you can use predefined name placeholders:
-
-* stable release `filename`: `julia-$version-$osarch.$extension`
-* nightly release `latest_filename`: `"julia-latest-$osbit.$extension"`
+Please check out [register new mirror](register_mirror.md).

--- a/README_zh.md
+++ b/README_zh.md
@@ -91,6 +91,9 @@ _跨平台的 Julia 一键安装脚本_
 - 下载： 用 `--sys musl` 来下载基于`musl`的版本，以及用`--sys linux` 来下载glibc的版本
 
 
+在你已经提前知道最近的镜像站的情况下， 环境变量 `JILL_UPSTREAM` 可以用来关闭 `jill` 的 “查询最近的上游” 这一功能，
+从而加速整个 `jill` 的下载过程。 （不过 `jill --upstream` 的优先级更高一些）
+
 ## 案例 -- Cron
 
 通过使用`cron`，`jill` 还能够保证在你的服务器上提供一个最新版本的每日构建版：
@@ -105,7 +108,3 @@ PATH=/usr/local/bin:/usr/sbin:/usr/sbin:/usr/bin:/sbin:/bin
 
 类似地，你也可以通过加一个 `jill install --confirm` 来保证 `julia` 永远是最新地稳定发行版。一旦有新的 Julia 版本
 发布了，`jill` 就能够下载到它 -- 你甚至不需要更新`jill`。
-
-## 镜像源的搭建
-
-Check the [English version](README.md) :)

--- a/jill/__main__.py
+++ b/jill/__main__.py
@@ -1,6 +1,7 @@
 from .download import download_package
 from .install import install_julia
 from .utils import show_upstream
+from .mirror import mirror
 import fire
 import logging
 import os
@@ -13,7 +14,8 @@ def main():
     fire.Fire({
         'download': download_package,
         'install': install_julia,
-        'upstream': show_upstream
+        'upstream': show_upstream,
+        'mirror': mirror
     }, name="jill")
 
 

--- a/jill/config/alias.json
+++ b/jill/config/alias.json
@@ -1,0 +1,14 @@
+{
+    "Arch": {
+        "x86": "i686",
+        "x64": "x86_64",
+        "armv8": "aarch64",
+        "armv7": "armv7l"
+    },
+    "OS": {
+        "macos": "mac",
+        "darwin": "mac",
+        "windows": "winnt",
+        "win": "winnt"
+    }
+}

--- a/jill/config/placeholders.json
+++ b/jill/config/placeholders.json
@@ -1,0 +1,38 @@
+{
+    "sys": {},
+    "os": {
+        "winnt": "win"
+    },
+    "arch": {
+        "i686": "x86",
+        "x86_64": "x64"
+    },
+    "osarch": {
+        "win-i686": "win32",
+        "win-x86_64": "win64",
+        "mac-x86_64": "mac64"
+    },
+    "osbit": {
+        "wini686": "win32",
+        "winx86_64": "win64",
+        "macx86_64": "mac64",
+        "linuxx86_64": "linux64",
+        "linuxi686": "linux32",
+        "freebsdx86_64": "freebsd64",
+        "freebsdi686": "freebsd32"
+    },
+    "extension": {
+        "winnt": "exe",
+        "linux": "tar.gz",
+        "mac": "dmg",
+        "freebsd": "tar.gz",
+        "musl": "tar.gz"
+    },
+    "bit": {
+        "i686": 32,
+        "x86_64": 64,
+        "aarch64": 64,
+        "armv7l": 32
+    }
+
+}

--- a/jill/config/sources.json
+++ b/jill/config/sources.json
@@ -7,7 +7,8 @@
             ],
             "latest_urls": [
                 "https://julialangnightlies-s3.julialang.org/bin/$sys/$arch/$latest_filename"
-            ]
+            ],
+            "versions": "https://julialang-s3.julialang.org/bin/versions.json"
         },
         "BFSU": {
             "name": "Beijing Foreign Studies University",
@@ -16,7 +17,8 @@
             ],
             "latest_urls": [
                 ""
-            ]
+            ],
+            "versions": "https://mirrors.bfsu.edu.cn/julia-releases/bin/versions.json"
         },
         "TUNA": {
             "name": "Tsinghua University TUNA Association",
@@ -26,7 +28,8 @@
             ],
             "latest_urls": [
                 ""
-            ]
+            ],
+            "versions": "https://mirrors.tuna.tsinghua.edu.cn/julia-releases/bin/versions.json"
         },
         "USTC": {
             "name": "University of Science and Technology of China",
@@ -35,7 +38,8 @@
             ],
             "latest_urls": [
                 ""
-            ]
+            ],
+            "versions": "https://mirrors.ustc.edu.cn/julia-releases/bin/versions.json"
         },
         "SJTUG": {
              "name": "Shanghai Jiao Tong University Linux User Group",
@@ -44,7 +48,8 @@
              ],
              "latest_urls": [
                  ""
-             ]
+             ],
+             "versions": "https://mirrors.sjtug.sjtu.edu.cn/julia-releases/bin/versions.json"
          }
     }
 }

--- a/jill/config/versions-schema.json
+++ b/jill/config/versions-schema.json
@@ -1,0 +1,128 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "type": "object",
+    "additionalProperties": {
+        "$ref": "#/definitions/WelcomeValue"
+    },
+    "definitions": {
+        "WelcomeValue": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/File"
+                    }
+                },
+                "stable": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "files",
+                "stable"
+            ],
+            "title": "WelcomeValue"
+        },
+        "File": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "triplet": {
+                    "$ref": "#/definitions/Triplet"
+                },
+                "kind": {
+                    "$ref": "#/definitions/Kind"
+                },
+                "arch": {
+                    "$ref": "#/definitions/Arch"
+                },
+                "sha256": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "os": {
+                    "$ref": "#/definitions/OS"
+                },
+                "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "https"
+                    ],
+                    "qt-uri-extensions": [
+                        ".dmg",
+                        ".exe",
+                        ".gz",
+                        ".zip"
+                    ]
+                },
+                "asc": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "arch",
+                "kind",
+                "os",
+                "sha256",
+                "size",
+                "triplet",
+                "url",
+                "version"
+            ],
+            "title": "File"
+        },
+        "Arch": {
+            "type": "string",
+            "enum": [
+                "x86_64",
+                "i686",
+                "powerpc64le",
+                "aarch64",
+                "armv7l"
+            ],
+            "title": "Arch"
+        },
+        "Kind": {
+            "type": "string",
+            "enum": [
+                "archive",
+                "installer"
+            ],
+            "title": "Kind"
+        },
+        "OS": {
+            "type": "string",
+            "enum": [
+                "mac",
+                "winnt",
+                "linux",
+                "freebsd"
+            ],
+            "title": "OS"
+        },
+        "Triplet": {
+            "type": "string",
+            "enum": [
+                "x86_64-apple-darwin14",
+                "x86_64-w64-mingw32",
+                "i686-w64-mingw32",
+                "x86_64-linux-gnu",
+                "i686-linux-gnu",
+                "powerpc64le-linux-gnu",
+                "aarch64-linux-gnu",
+                "armv7l-linux-gnueabihf",
+                "x86_64-unknown-freebsd11.1",
+                "x86_64-linux-musl"
+            ],
+            "title": "Triplet"
+        }
+    }
+}

--- a/jill/download.py
+++ b/jill/download.py
@@ -116,7 +116,8 @@ def download_package(version=None, sys=None, arch=None, *,
         verify_upstream(upstream)
     wrong_args = False
     try:
-        version = latest_version(version, system, architecture)
+        version = latest_version(
+            version, system, architecture, upstream=upstream)
     except ValueError:
         # hide the nested error stack :P
         wrong_args = True
@@ -130,7 +131,8 @@ def download_package(version=None, sys=None, arch=None, *,
 
     release_str = f"{version}-{system}-{architecture}"
     if do_release_check:
-        rst = is_version_released(version, system, architecture)
+        rst = is_version_released(
+            version, system, architecture, upstream=upstream)
         if not rst:
             msg = f"failed to find {release_str} in available upstream. Please try it later."
             logging.info(msg)

--- a/jill/install.py
+++ b/jill/install.py
@@ -267,7 +267,7 @@ def install_julia_windows(package_path,
     dest_path = os.path.join(install_dir,
                              f"julia-{f_minor_version(version)}")
     if os.path.exists(dest_path):
-        shutil.rmtree(dest_path)
+        shutil.rmtree(dest_path, ignore_errors=True)
         msg = f"{color.YELLOW}remove previous Julia installation:"
         msg += f" {dest_path}{color.END}"
         print(msg)

--- a/jill/install.py
+++ b/jill/install.py
@@ -21,7 +21,7 @@ def default_depot_path():
 
 def default_symlink_dir():
     system = current_system()
-    if system == "windows":
+    if system == "winnt":
         return os.path.expanduser(r"~\AppData\Local\julias\bin")
     if getpass.getuser() == "root":
         # available to all users
@@ -33,14 +33,14 @@ def default_symlink_dir():
 
 def default_install_dir():
     system = current_system()
-    if system == "macos":
+    if system == "mac":
         return "/Applications"
     elif system in ["linux", "freebsd"]:
         if getpass.getuser() == "root":
             return "/opt/julias"
         else:
             return os.path.expanduser("~/packages/julias")
-    elif system == "windows":
+    elif system == "winnt":
         return os.path.expanduser(r"~\AppData\Local\julias")
     else:
         raise ValueError(f"Unsupported system: {system}")
@@ -398,12 +398,12 @@ def install_julia(version=None, *,
     if not package_path:
         return False
 
-    if system == "macos":
+    if system == "mac":
         installer = install_julia_mac
     elif system in ["linux", "freebsd", "musl"]:
         # technically it's tarball installer
         installer = install_julia_linux
-    elif system == "windows":
+    elif system == "winnt":
         installer = install_julia_windows
     else:
         os.remove(package_path)

--- a/jill/install.py
+++ b/jill/install.py
@@ -377,7 +377,7 @@ def install_julia(version=None, *,
     wrong_args = False
     try:
         version = latest_version(
-            version, system, arch, update=True, upstream=upstream)
+            version, system, arch, upstream=upstream)
     except ValueError:
         # hide the nested error stack :P
         wrong_args = True

--- a/jill/mirror.py
+++ b/jill/mirror.py
@@ -1,0 +1,226 @@
+from .utils.defaults import default_path_template
+from .utils.defaults import default_filename_template
+from .utils.defaults import default_latest_filename_template
+from .utils import generate_info
+from .utils import read_releases
+from .utils import current_system
+from .download import download_package
+
+from string import Template
+from itertools import product
+
+import semantic_version
+
+import json
+import os
+import logging
+import time
+
+
+class MirrorConfig:
+    def __init__(self, configfile, outdir):
+        if current_system() == "windows":
+            # Windows users (e.g., me) sometimes confuse the use of \\ and \
+            outdir = outdir.replace("\\\\", "\\")
+        self.configfile = os.path.abspath(os.path.expanduser(configfile))
+        self.outdir = outdir
+
+    @property
+    def config(self):
+        if not os.path.isfile(self.configfile):
+            return {}
+        with open(self.configfile, 'r') as f:
+            return json.load(f)
+
+    @property
+    def require_latest(self) -> bool:
+        """True to mirror nightly build as well"""
+        require_latest = self.config.get("require_latest", True)
+        if isinstance(require_latest, bool):
+            return require_latest
+        if require_latest in ["False", "false"]:
+            require_latest = False
+        elif require_latest in ["True", "true"]:
+            require_latest = True
+        else:
+            raise(ValueError(
+                f"Unrecognized require_latest value: {require_latest}"))
+        return require_latest
+
+    @property
+    def stable_only(self) -> bool:
+        """True to not mirror alpha/beta/rc releases"""
+        stable_only = self.config.get("stable_only", False)
+        if isinstance(stable_only, bool):
+            return stable_only
+        if stable_only in ["False", "false"]:
+            stable_only = False
+        elif stable_only in ["True", "true"]:
+            stable_only = True
+        else:
+            raise(ValueError(f"Unrecognized stable_only value: {stable_only}"))
+        return stable_only
+
+    @property
+    def overwrite(self) -> bool:
+        """
+        True to overwrite existing stable releases as well.
+        Nightly builds will be overwrite always regardless of this setting.
+        """
+        overwrite = self.config.get("overwrite", False)
+        if isinstance(overwrite, bool):
+            return overwrite
+        if overwrite in ["False", "false"]:
+            overwrite = False
+        elif overwrite in ["True", "true"]:
+            overwrite = True
+        else:
+            raise(ValueError(f"Unrecognized overwrite value: {overwrite}"))
+        return overwrite
+
+    @property
+    def path_template(self):
+        """path template to define the folder structure of releases"""
+        return Template(self.config.get("path", default_path_template))
+
+    @property
+    def filename_template(self):
+        """filename template for stable releases"""
+        return Template(self.config.get("filename", default_filename_template))
+
+    @property
+    def latest_filename_template(self):
+        """filename template for nightly builds"""
+        return Template(self.config.get("latest_filename",
+                                        default_latest_filename_template))
+
+    @property
+    def version(self):
+        versions = list(set(map(lambda x: x[0],
+                                read_releases(stable_only=True))))
+        # not using our extended Version
+        versions.sort(key=lambda ver: semantic_version.Version(ver))
+        if self.require_latest:
+            versions.append("latest")
+        return versions
+
+    @property
+    def system(self):
+        return set(map(lambda x: x[1], read_releases()))
+
+    @property
+    def architecture(self):
+        return set(map(lambda x: x[2], read_releases()))
+
+    @property
+    def releases(self):
+        return read_releases(stable_only=self.stable_only)
+
+    def logging(self):
+        logging.info(f"mirror configuration:")
+        logging.info(f"    - configfile: {self.configfile}")
+        logging.info(f"    - outdir: {self.outdir}")
+        logging.info(f"    - path: {self.path_template.template}")
+        logging.info(f"    - filename: {self.filename_template.template}")
+        logging.info(f"    - versions: {', '.join(self.version)}")
+        logging.info(f"    - systems: {', '.join(self.system)}")
+        logging.info(f"    - architectures: {', '.join(self.architecture)}")
+        logging.info(f"    - overwrite: {self.overwrite}")
+        logging.info(f"    - require_latest: {self.require_latest}")
+
+    def get_outpath(self, plain_version, system, architecture):
+        configs = generate_info(plain_version, system, architecture)
+        if plain_version in ["latest"]:
+            t_file = self.latest_filename_template
+        else:
+            t_file = self.filename_template
+        configs["filename"] = t_file.substitute(**configs)
+        return self.path_template.substitute(**configs)
+
+
+class Mirror:
+    def __init__(self,  config):
+        if not isinstance(config, MirrorConfig):
+            config = MirrorConfig(config)
+        self.config = config
+
+    def pull_releases(self, *,
+                      upstream=None):
+        for item in self.config.releases:
+            filepath = self.config.get_outpath(*item)
+            outpath = os.path.join(self.config.outdir, filepath)
+            outdir, filename = os.path.split(outpath)
+
+            logging.info(f"start to pull {filepath}")
+            overwrite = self.config.overwrite
+            download_package(*item,
+                             outdir=outdir,
+                             upstream=upstream,
+                             overwrite=overwrite)
+        if self.config.require_latest:
+            for (system, arch) in product(self.config.system, self.config.architecture):
+                item = "latest", system, arch
+                filepath = self.config.get_outpath(*item)
+                outpath = os.path.join(self.config.outdir, filepath)
+                outdir, filename = os.path.split(outpath)
+
+                logging.info(f"start to pull {filepath}")
+                download_package(*item,
+                                 outdir=outdir,
+                                 upstream=upstream,
+                                 overwrite=True)
+
+
+def mirror(outdir="julia_pkg", *,
+           period=0,
+           upstream=None,
+           logfile="mirror.log",
+           config="mirror.json"):
+    """
+    Download/sync all Julia releases
+
+    1. checks if there're new julia releases
+    2. downloads all releases Julia releases into `outdir` (default `./julia_pkg`)
+    3. (Optional): with flag `--period PERIOD`, it will repeat step 1 and 2 every `PERIOD` seconds
+
+    If you want to modify the default mirror configuration, then provide a `mirror.json` file and
+    pass the path to `config`. By default it's at the current directory.
+    Arguments:
+      outdir: default 'julia_pkg'.
+      period: the time between two sync operation. 0(default) to sync once.
+      upstream:
+        manually choose a download upstream. For example, set it to "Official"
+        if you want to download from JuliaComputing's s3 buckets.
+      config:
+        path to mirror config file
+      logfile:
+        path to mirror log file
+    """
+    log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    period = int(period)
+    upstream = None if upstream == "None" else upstream
+
+    logger = logging.getLogger('')
+    fh = logging.FileHandler(logfile)
+    fh.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(log_format)
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+    # TODO: filter out urllib3 debug logs
+
+    m = Mirror(MirrorConfig(config, outdir=outdir))
+    m.config.logging()
+    while True:
+        logging.info("START: pull Julia releases")
+        m.pull_releases(upstream=upstream)
+        logging.info("END: pulling Julia releases")
+
+        if period == 0:
+            return True
+        else:
+            time.sleep(period)
+
+        # refresh configuration at each re-pull
+        logging.info("reload configure file")
+        m.config = MirrorConfig(config, outdir=outdir)
+        m.config.logging()

--- a/jill/tests/tests_alias.py
+++ b/jill/tests/tests_alias.py
@@ -1,0 +1,46 @@
+from jill.utils.filters import canonicalize_arch, canonicalize_sys
+
+import unittest
+
+
+class TestAlias(unittest.TestCase):
+    def test_canonicalize_sys(self):
+        self.assertEqual(canonicalize_sys("winnt"), "winnt")
+        self.assertEqual(canonicalize_sys("windows"), "winnt")
+        self.assertEqual(canonicalize_sys("win"), "winnt")
+
+        self.assertEqual(canonicalize_sys("mac"), "mac")
+        self.assertEqual(canonicalize_sys("macos"), "mac")
+        self.assertEqual(canonicalize_sys("darwin"), "mac")
+
+        self.assertEqual(canonicalize_sys("linux"), "linux")
+
+        self.assertEqual(canonicalize_sys("freebsd"), "freebsd")
+
+        # case-insensitive
+        self.assertEqual(canonicalize_sys("WiNnT"), "winnt")
+
+        # jill might just break if it maps musl to other strings...
+        self.assertEqual(canonicalize_sys("musl"), "musl")
+
+    def test_canonicalize_arch(self):
+        self.assertEqual(canonicalize_arch("i686"), "i686")
+        self.assertEqual(canonicalize_arch("I686"), "i686")
+        self.assertEqual(canonicalize_arch("x86"), "i686")
+        self.assertEqual(canonicalize_arch("X86"), "i686")
+
+        self.assertEqual(canonicalize_arch("x64"), "x86_64")
+        self.assertEqual(canonicalize_arch("X64"), "x86_64")
+        self.assertEqual(canonicalize_arch("x86_64"), "x86_64")
+        self.assertEqual(canonicalize_arch("X86_64"), "x86_64")
+
+        self.assertEqual(canonicalize_arch("aarch64"), "aarch64")
+        self.assertEqual(canonicalize_arch("armv8"), "aarch64")
+        self.assertEqual(canonicalize_arch("ARMv8"), "aarch64")
+
+        self.assertEqual(canonicalize_arch("armv7l"), "armv7l")
+        self.assertEqual(canonicalize_arch("armv7"), "armv7l")
+        self.assertEqual(canonicalize_arch("ARMv7"), "armv7l")
+
+        # case-insensitive
+        self.assertEqual(canonicalize_arch("aArCH64"), "aarch64")

--- a/jill/tests/tests_filters.py
+++ b/jill/tests/tests_filters.py
@@ -89,73 +89,73 @@ class TestFilters(unittest.TestCase):
     def test_arch(self):
         self.assertEqual(f_arch("x86_64"), "x64")
         self.assertEqual(f_arch("i686"), "x86")
-        self.assertEqual(f_arch("ARMv8"), "aarch64")
-        self.assertEqual(f_arch("ARMv7"), "armv7l")
+        self.assertEqual(f_arch("aarch64"), "aarch64")
+        self.assertEqual(f_arch("armv7l"), "armv7l")
 
         self.assertEqual(f_Arch("x86_64"), "X64")
         self.assertEqual(f_Arch("i686"), "X86")
-        self.assertEqual(f_Arch("ARMv8"), "Aarch64")
-        self.assertEqual(f_Arch("ARMv7"), "Armv7l")
+        self.assertEqual(f_Arch("aarch64"), "Aarch64")
+        self.assertEqual(f_Arch("armv7l"), "Armv7l")
 
         self.assertEqual(f_ARCH("x86_64"), "X64")
         self.assertEqual(f_ARCH("i686"), "X86")
-        self.assertEqual(f_ARCH("ARMv8"), "AARCH64")
-        self.assertEqual(f_ARCH("ARMv7"), "ARMV7L")
+        self.assertEqual(f_ARCH("aarch64"), "AARCH64")
+        self.assertEqual(f_ARCH("armv7l"), "ARMV7L")
 
     def test_system(self):
-        self.assertEqual(f_system("windows"), "windows")
+        self.assertEqual(f_system("winnt"), "winnt")
         self.assertEqual(f_system("linux"), "linux")
         self.assertEqual(f_system("freebsd"), "freebsd")
-        self.assertEqual(f_system("macos"), "macos")
+        self.assertEqual(f_system("mac"), "mac")
 
-        self.assertEqual(f_System("windows"), "Windows")
+        self.assertEqual(f_System("winnt"), "Winnt")
         self.assertEqual(f_System("linux"), "Linux")
         self.assertEqual(f_System("freebsd"), "Freebsd")
-        self.assertEqual(f_System("macos"), "Macos")
+        self.assertEqual(f_System("mac"), "Mac")
 
-        self.assertEqual(f_SYSTEM("windows"), "WINDOWS")
+        self.assertEqual(f_SYSTEM("winnt"), "WINNT")
         self.assertEqual(f_SYSTEM("linux"), "LINUX")
         self.assertEqual(f_SYSTEM("freebsd"), "FREEBSD")
-        self.assertEqual(f_SYSTEM("macos"), "MACOS")
+        self.assertEqual(f_SYSTEM("mac"), "MAC")
 
     def test_sys(self):
-        self.assertEqual(f_sys("windows"), "winnt")
+        self.assertEqual(f_sys("winnt"), "winnt")
         self.assertEqual(f_sys("linux"), "linux")
         self.assertEqual(f_sys("freebsd"), "freebsd")
-        self.assertEqual(f_sys("macos"), "mac")
+        self.assertEqual(f_sys("mac"), "mac")
 
-        self.assertEqual(f_Sys("windows"), "Winnt")
+        self.assertEqual(f_Sys("winnt"), "Winnt")
         self.assertEqual(f_Sys("linux"), "Linux")
         self.assertEqual(f_Sys("freebsd"), "Freebsd")
-        self.assertEqual(f_Sys("macos"), "Mac")
+        self.assertEqual(f_Sys("mac"), "Mac")
 
-        self.assertEqual(f_SYS("windows"), "WINNT")
+        self.assertEqual(f_SYS("winnt"), "WINNT")
         self.assertEqual(f_SYS("linux"), "LINUX")
         self.assertEqual(f_SYS("freebsd"), "FREEBSD")
-        self.assertEqual(f_SYS("macos"), "MAC")
+        self.assertEqual(f_SYS("mac"), "MAC")
 
     def test_os(self):
-        self.assertEqual(f_os("windows"), "win")
+        self.assertEqual(f_os("winnt"), "win")
         self.assertEqual(f_os("linux"), "linux")
         self.assertEqual(f_os("freebsd"), "freebsd")
-        self.assertEqual(f_os("macos"), "mac")
+        self.assertEqual(f_os("mac"), "mac")
 
-        self.assertEqual(f_Os("windows"), "Win")
+        self.assertEqual(f_Os("winnt"), "Win")
         self.assertEqual(f_Os("linux"), "Linux")
         self.assertEqual(f_Os("freebsd"), "Freebsd")
-        self.assertEqual(f_Os("macos"), "Mac")
+        self.assertEqual(f_Os("mac"), "Mac")
 
-        self.assertEqual(f_OS("windows"), "WIN")
+        self.assertEqual(f_OS("winnt"), "WIN")
         self.assertEqual(f_OS("linux"), "LINUX")
         self.assertEqual(f_OS("freebsd"), "FREEBSD")
-        self.assertEqual(f_OS("macos"), "MAC")
+        self.assertEqual(f_OS("mac"), "MAC")
 
     def test_osarch(self):
         self.assertEqual(f_osarch("win", "i686"), "win32")
         self.assertEqual(f_osarch("win", "x86_64"), "win64")
         self.assertEqual(f_osarch("mac", "x86_64"), "mac64")
-        self.assertEqual(f_osarch("linux", "ARMv7"), "linux-armv7l")
-        self.assertEqual(f_osarch("linux", "ARMv8"), "linux-aarch64")
+        self.assertEqual(f_osarch("linux", "armv7l"), "linux-armv7l")
+        self.assertEqual(f_osarch("linux", "aarch64"), "linux-aarch64")
         self.assertEqual(f_osarch("linux", "i686"), "linux-i686")
         self.assertEqual(f_osarch("linux", "x86_64"), "linux-x86_64")
         self.assertEqual(f_osarch("freebsd", "x86_64"), "freebsd-x86_64")
@@ -163,8 +163,8 @@ class TestFilters(unittest.TestCase):
         self.assertEqual(f_Osarch("win", "i686"), "Win32")
         self.assertEqual(f_Osarch("win", "x86_64"), "Win64")
         self.assertEqual(f_Osarch("mac", "x86_64"), "Mac64")
-        self.assertEqual(f_Osarch("linux", "ARMv7"), "Linux-armv7l")
-        self.assertEqual(f_Osarch("linux", "ARMv8"), "Linux-aarch64")
+        self.assertEqual(f_Osarch("linux", "armv7l"), "Linux-armv7l")
+        self.assertEqual(f_Osarch("linux", "aarch64"), "Linux-aarch64")
         self.assertEqual(f_Osarch("linux", "i686"), "Linux-i686")
         self.assertEqual(f_Osarch("linux", "x86_64"), "Linux-x86_64")
         self.assertEqual(f_Osarch("freebsd", "x86_64"), "Freebsd-x86_64")
@@ -172,8 +172,8 @@ class TestFilters(unittest.TestCase):
         self.assertEqual(f_OSarch("win", "i686"), "WIN32")
         self.assertEqual(f_OSarch("win", "x86_64"), "WIN64")
         self.assertEqual(f_OSarch("mac", "x86_64"), "MAC64")
-        self.assertEqual(f_OSarch("linux", "ARMv7"), "LINUX-armv7l")
-        self.assertEqual(f_OSarch("linux", "ARMv8"), "LINUX-aarch64")
+        self.assertEqual(f_OSarch("linux", "armv7l"), "LINUX-armv7l")
+        self.assertEqual(f_OSarch("linux", "aarch64"), "LINUX-aarch64")
         self.assertEqual(f_OSarch("linux", "i686"), "LINUX-i686")
         self.assertEqual(f_OSarch("linux", "x86_64"), "LINUX-x86_64")
         self.assertEqual(f_OSarch("freebsd", "x86_64"), "FREEBSD-x86_64")
@@ -182,8 +182,8 @@ class TestFilters(unittest.TestCase):
         self.assertEqual(f_osbit("win", "i686"), "win32")
         self.assertEqual(f_osbit("win", "x86_64"), "win64")
         self.assertEqual(f_osbit("mac", "x86_64"), "mac64")
-        self.assertEqual(f_osbit("linux", "ARMv7"), "linuxarmv7l")
-        self.assertEqual(f_osbit("linux", "ARMv8"), "linuxaarch64")
+        self.assertEqual(f_osbit("linux", "armv7l"), "linuxarmv7l")
+        self.assertEqual(f_osbit("linux", "aarch64"), "linuxaarch64")
         self.assertEqual(f_osbit("linux", "i686"), "linux32")
         self.assertEqual(f_osbit("linux", "x86_64"), "linux64")
         self.assertEqual(f_osbit("freebsd", "x86_64"), "freebsd64")
@@ -192,14 +192,14 @@ class TestFilters(unittest.TestCase):
     def test_bit(self):
         self.assertEqual(f_bit("i686"), 32)
         self.assertEqual(f_bit("x86_64"), 64)
-        self.assertEqual(f_bit("ARMv7"), 32)
-        self.assertEqual(f_bit("ARMv8"), 64)
+        self.assertEqual(f_bit("armv7l"), 32)
+        self.assertEqual(f_bit("aarch64"), 64)
 
     def test_extension(self):
         self.assertEqual(f_extension("linux"), "tar.gz")
-        self.assertEqual(f_extension("macos"), "dmg")
+        self.assertEqual(f_extension("mac"), "dmg")
         self.assertEqual(f_extension("freebsd"), "tar.gz")
-        self.assertEqual(f_extension("windows"), "exe")
+        self.assertEqual(f_extension("winnt"), "exe")
 
     def test_latest_filename(self):
         info = generate_info("latest", "linux", "i686")
@@ -209,18 +209,18 @@ class TestFilters(unittest.TestCase):
         self.assertEqual(info["latest_filename"],
                          "julia-latest-linux64.tar.gz")
 
-        info = generate_info("latest", "linux", "ARMv8")
+        info = generate_info("latest", "linux", "aarch64")
         self.assertEqual(info["latest_filename"],
                          "julia-latest-linuxaarch64.tar.gz")
 
-        info = generate_info("latest", "windows", "i686")
+        info = generate_info("latest", "winnt", "i686")
         self.assertEqual(info["latest_filename"],
                          "julia-latest-win32.exe")
-        info = generate_info("latest", "windows", "x86_64")
+        info = generate_info("latest", "winnt", "x86_64")
         self.assertEqual(info["latest_filename"],
                          "julia-latest-win64.exe")
 
-        info = generate_info("latest", "macos", "x86_64")
+        info = generate_info("latest", "mac", "x86_64")
         self.assertEqual(info["latest_filename"],
                          "julia-latest-mac64.dmg")
 
@@ -231,21 +231,21 @@ class TestFilters(unittest.TestCase):
         info = generate_info("1.3.0", "linux", "x86_64")
         self.assertEqual(info["filename"],
                          "julia-1.3.0-linux-x86_64.tar.gz")
-        info = generate_info("1.3.0", "linux", "ARMv7")
+        info = generate_info("1.3.0", "linux", "armv7l")
         self.assertEqual(info["filename"],
                          "julia-1.3.0-linux-armv7l.tar.gz")
-        info = generate_info("1.3.0", "linux", "ARMv8")
+        info = generate_info("1.3.0", "linux", "aarch64")
         self.assertEqual(info["filename"],
                          "julia-1.3.0-linux-aarch64.tar.gz")
 
-        info = generate_info("1.3.0", "windows", "i686")
+        info = generate_info("1.3.0", "winnt", "i686")
         self.assertEqual(info["filename"],
                          "julia-1.3.0-win32.exe")
-        info = generate_info("1.3.0", "windows", "x86_64")
+        info = generate_info("1.3.0", "winnt", "x86_64")
         self.assertEqual(info["filename"],
                          "julia-1.3.0-win64.exe")
 
-        info = generate_info("1.3.0", "macos", "x86_64")
+        info = generate_info("1.3.0", "mac", "x86_64")
         self.assertEqual(info["filename"],
                          "julia-1.3.0-mac64.dmg")
 

--- a/jill/tests/tests_versions.py
+++ b/jill/tests/tests_versions.py
@@ -6,52 +6,50 @@ import unittest
 
 class TestVersions(unittest.TestCase):
     def test_is_version_released(self):
-        self.assertTrue(is_version_released("1.1.0", "windows", "x86_64"))
+        self.assertTrue(is_version_released("1.1.0", "winnt", "x86_64"))
         self.assertFalse(is_version_released("1.1.0", "whatever", "x86_64"))
 
-        self.assertTrue(is_version_released("1.1.1", "macos", "x86_64"))
-        self.assertTrue(is_version_released("1.6.0", "windows", "x86_64"))
+        self.assertTrue(is_version_released("1.1.1", "mac", "x86_64"))
+        self.assertTrue(is_version_released("1.6.0", "winnt", "x86_64"))
         self.assertTrue(is_version_released("1.6.0", "linux", "x86_64"))
-        
-        self.assertFalse(is_version_released("1.5.10", "windows", "x86_64"))
 
-        self.assertTrue(is_version_released("0.1.2", "macos", "x86_64"))
-        self.assertFalse(is_version_released("0.1.2", "windows", "x86_64"))
-        self.assertFalse(is_version_released("0.1.2", "macos", "i686"))
+        self.assertFalse(is_version_released("1.5.10", "winnt", "x86_64"))
 
-        self.assertTrue(is_version_released("latest", "macos", "x86_64"))
+        self.assertTrue(is_version_released("0.1.2", "mac", "x86_64"))
+        self.assertFalse(is_version_released("0.1.2", "winnt", "x86_64"))
+        self.assertFalse(is_version_released("0.1.2", "mac", "i686"))
 
-        self.assertTrue(is_version_released("1.6.0-rc1", "macos", "x86_64", stable_only=False))
-        self.assertFalse(is_version_released("1.6.0-rc1", "macos", "x86_64", stable_only=True))
+        self.assertTrue(is_version_released("latest", "mac", "x86_64"))
+
+        self.assertTrue(is_version_released(
+            "1.6.0-rc1", "mac", "x86_64", stable_only=False))
+        self.assertFalse(is_version_released(
+            "1.6.0-rc1", "mac", "x86_64", stable_only=True))
 
     def test_latest_version(self):
         self.assertEqual(
-            latest_version("latest", "windows", "x86_64"),
+            latest_version("latest", "winnt", "x86_64"),
             "latest")
         self.assertEqual(
-            latest_version("0.7", "windows", "x86_64"),
+            latest_version("0.7", "winnt", "x86_64"),
             "0.7.0")
         self.assertEqual(
-            latest_version("1.1", "windows", "x86_64"),
+            latest_version("1.1", "winnt", "x86_64"),
             "1.1.1")
         self.assertEqual(
-            latest_version("1.5", "macos", "x86_64"),
+            latest_version("1.5", "mac", "x86_64"),
             "1.5.4")
-        self.assertEqual(
-            latest_version("1.8", "macos", "x86_64"),
-            "1.6.0")
         self.assertNotEqual(
-            latest_version("", "macos", "x86_64"),
+            latest_version("", "mac", "x86_64"),
             "latest")
+        self.assertRaises(ValueError, latest_version,
+                          "", "illegal_system", "x86_64")
         self.assertEqual(
-            latest_version("", "illegal_system", "x86_64"),
-            latest_version("", "linux", "x86_64"))
-        self.assertEqual(
-            latest_version("1.4.0-rc1", "windows", "x86_64"),
+            latest_version("1.4.0-rc1", "winnt", "x86_64"),
             "1.4.0-rc1")
         self.assertEqual(
-            latest_version("999.999.999", "windows", "x86_64"),
+            latest_version("999.999.999", "winnt", "x86_64"),
             "999.999.999")
         self.assertEqual(
-            latest_version("1.6", "linux", "ARMv7"),
+            latest_version("1.6", "linux", "armv7l"),
             "1.4.1")

--- a/jill/tests/tests_versions.py
+++ b/jill/tests/tests_versions.py
@@ -15,10 +15,6 @@ class TestVersions(unittest.TestCase):
 
         self.assertFalse(is_version_released("1.5.10", "winnt", "x86_64"))
 
-        self.assertTrue(is_version_released("0.1.2", "mac", "x86_64"))
-        self.assertFalse(is_version_released("0.1.2", "winnt", "x86_64"))
-        self.assertFalse(is_version_released("0.1.2", "mac", "i686"))
-
         self.assertTrue(is_version_released("latest", "mac", "x86_64"))
 
         self.assertTrue(is_version_released(

--- a/jill/utils/__init__.py
+++ b/jill/utils/__init__.py
@@ -1,5 +1,4 @@
 from .filters import generate_info
-from .filters import is_valid_release
 from .gpg_utils import verify_gpg
 from .interactive_utils import query_yes_no
 from .interactive_utils import color
@@ -18,13 +17,13 @@ from .source_utils import verify_upstream
 __all__ = [
     # filters
     "generate_info",
-    "is_valid_release",
 
     # gpg_utils
     "verify_gpg",
 
     # interactive_utils
     "query_yes_no",
+    "color",
 
     # mount_utils
     "TarMounter", "DmgMounter",

--- a/jill/utils/defaults.py
+++ b/jill/utils/defaults.py
@@ -1,5 +1,8 @@
 from .sys_utils import current_system
 import os
+import json
+
+from typing import Dict
 
 # this file isn't really a python script
 # just some configuration constants
@@ -31,8 +34,54 @@ SOURCE_CONFIGFILE = get_configfiles("sources.json")
 GPG_PUBLIC_KEY_PATH = os.path.join(PKG_ROOT, ".gnupg", "juliareleases.asc")
 VERSIONS_URL = "https://julialang-s3.julialang.org/bin/versions.json"
 VERSIONS_SCHEMA_URL = "https://julialang-s3.julialang.org/bin/versions-schema.json"
-VERSIONS_SCHEMA_FILE_PATH = os.path.join(
-    PKG_ROOT, "config", "versions-schema.json")
+
+
+def load_versions_schema(download=False, cache=dict()) -> Dict:
+    """
+        Load the schema configs.
+
+        The schema is used to validate if the downloaded `versions.json` are valid.
+    """
+    configfile = os.path.join(PKG_ROOT, "config", "versions-schema.json")
+    # Avoid unnecessary IO reads by caching the content into memeory
+    if not cache:
+        with open(configfile, "r") as file:
+            schema = json.load(file)
+        cache.update(schema)
+    return cache
+
+
+def load_alias(cache=dict()) -> Dict:
+    """
+        Load the alias configs.
+
+        For better user experiences, jill allows alias for some os/arch, e.g., `windows`->`winnt`.
+    """
+    configfile = os.path.join(PKG_ROOT, "config", "alias.json")
+    # Avoid unnecessary IO reads by caching the content into memeory
+    if not cache:
+        with open(configfile, "r") as file:
+            alias = json.load(file)
+        cache.update(alias)
+    return cache
+
+
+def load_placeholder(
+        cache=dict()) -> Dict:
+    """
+        Load the placeholder configs.
+
+        Placeholders are used to generate URLs from given template, see also "sources.json"
+        for an example.
+    """
+    # Avoid unnecessary IO reads by caching the content into memeory
+    configfile = os.path.join(PKG_ROOT, "config", "placeholders.json")
+    if not cache:
+        with open(configfile, "r") as file:
+            schema = json.load(file)
+        cache.update(schema)
+    return cache
+
 
 default_filename_template = "julia-$version-$osarch.$extension"
 default_latest_filename_template = "julia-latest-$osbit.$extension"

--- a/jill/utils/defaults.py
+++ b/jill/utils/defaults.py
@@ -30,6 +30,9 @@ def get_configfiles(filename):
 SOURCE_CONFIGFILE = get_configfiles("sources.json")
 GPG_PUBLIC_KEY_PATH = os.path.join(PKG_ROOT, ".gnupg", "juliareleases.asc")
 VERSIONS_URL = "https://julialang-s3.julialang.org/bin/versions.json"
+VERSIONS_SCHEMA_URL = "https://julialang-s3.julialang.org/bin/versions-schema.json"
+VERSIONS_SCHEMA_FILE_PATH = os.path.join(
+    PKG_ROOT, "config", "versions-schema.json")
 
 default_filename_template = "julia-$version-$osarch.$extension"
 default_latest_filename_template = "julia-latest-$osbit.$extension"

--- a/jill/utils/defaults.py
+++ b/jill/utils/defaults.py
@@ -32,7 +32,7 @@ def get_configfiles(filename):
 
 SOURCE_CONFIGFILE = get_configfiles("sources.json")
 GPG_PUBLIC_KEY_PATH = os.path.join(PKG_ROOT, ".gnupg", "juliareleases.asc")
-VERSIONS_URL = "https://julialang-s3.julialang.org/bin/versions.json"
+DEFAULT_VERSIONS_URL = "https://julialang-s3.julialang.org/bin/versions.json"
 VERSIONS_SCHEMA_URL = "https://julialang-s3.julialang.org/bin/versions-schema.json"
 
 # for mirror usage: where releases are downloaded to

--- a/jill/utils/defaults.py
+++ b/jill/utils/defaults.py
@@ -35,6 +35,9 @@ GPG_PUBLIC_KEY_PATH = os.path.join(PKG_ROOT, ".gnupg", "juliareleases.asc")
 VERSIONS_URL = "https://julialang-s3.julialang.org/bin/versions.json"
 VERSIONS_SCHEMA_URL = "https://julialang-s3.julialang.org/bin/versions-schema.json"
 
+# for mirror usage: where releases are downloaded to
+default_path_template = "releases/$vminor_version/$filename"
+
 
 def load_versions_schema(download=False, cache=dict()) -> Dict:
     """

--- a/jill/utils/source_utils.py
+++ b/jill/utils/source_utils.py
@@ -26,6 +26,7 @@ class ReleaseSource:
                  name: str,
                  urls: List[str],
                  latest_urls: List[str],
+                 versions: str = None,
                  timeout=2.0):
         # seperate stable and nightly versions because:
         #   * JuliaComputing stores them in two different s3 buckets
@@ -38,6 +39,7 @@ class ReleaseSource:
         # TODO: make latest an optional config
         self.latest_url_templates = [Template(x) for x in latest_urls if x]
         self.timeout = timeout
+        self.versions_url = versions
         self._latencies = dict()  # type: ignore
 
     @property

--- a/jill/utils/sys_utils.py
+++ b/jill/utils/sys_utils.py
@@ -13,11 +13,11 @@ def current_system():
     if rst.lower() == "linux":
         return "linux"
     elif rst.lower() == "darwin":
-        return "macos"
+        return "mac"
     elif rst.lower() == "freebsd":
         return "freebsd"
     elif rst.lower() == "windows":
-        return "windows"
+        return "winnt"
     else:
         raise ValueError(f"Unsupported system {rst}")
 
@@ -25,9 +25,9 @@ def current_system():
 def current_architecture():
     arch = platform.machine()
     if arch.lower() == "aarch64":
-        return "ARMv8"
+        return "aarch64"
     elif arch.lower() == "armv7l":
-        return "ARMv7"
+        return "armv7l"
     elif arch.lower() == "i386":
         return "i686"
     elif arch.lower() == "amd64":

--- a/jill/utils/version_utils.py
+++ b/jill/utils/version_utils.py
@@ -110,7 +110,13 @@ def read_releases(stable_only=False) -> List[Tuple[str, str, str]]:
         if not stable_only or is_stable:
             files = item[1]['files']
             for file in files:
-                releases.append((ver, file['os'], file['arch']))
+                os = file['os']
+                libc = file['triplet'].split('-')[2]
+                if libc == "musl":
+                    # currently Julia tags musl as a system, e.g.,
+                    # https://julialang-s3.julialang.org/bin/musl/x64/1.5/julia-1.5.1-musl-x86_64.tar.gz
+                    os = "musl"
+                releases.append((ver, os, file['arch']))
     return releases
 
 

--- a/jill/utils/version_utils.py
+++ b/jill/utils/version_utils.py
@@ -95,7 +95,7 @@ def read_remote_json(url, cache=dict()):
     return cache
 
 
-def read_releases(stable_only=False) -> List[Tuple[str, str, str]]:
+def read_releases(minimal_version='0.6.0', stable_only=False) -> List[Tuple[str, str, str]]:
     """
     read release info from versions.json (VERSIONS_URL)
     The content will be cached so will only download the data once.
@@ -108,6 +108,15 @@ def read_releases(stable_only=False) -> List[Tuple[str, str, str]]:
         ver = item[0]
         is_stable = item[1]['stable']
         if not stable_only or is_stable:
+
+            # minimal_version works only when is_stable=True
+            try:
+                # TODO: a cleaner solution
+                if Version(ver) < Version(minimal_version):
+                    continue
+            except:
+                continue
+
             files = item[1]['files']
             for file in files:
                 os = file['os']

--- a/mirror.example.json
+++ b/mirror.example.json
@@ -3,5 +3,6 @@
     "latest_filename": "$latest_filename",
     "path": "releases/$vminor_version/$filename",
     "overwrite": "False",
-    "require_latest": "True"
+    "require_latest": "True",
+    "stable_only": "False"
 }

--- a/register_mirror.md
+++ b/register_mirror.md
@@ -1,0 +1,47 @@
+### Register new mirror
+
+If it's an public mirror and you want to share it worldwide. You can add an entry to the
+[public registry](jill/config/sources.json), make a PR, then I will tag a new release for that.
+
+If it's an internal mirror and you don't plan to make it public, you can create a config
+file at `~/.config/jill/sources.json` locally. The contents will be appended to
+the public registry and overwrite already existing items if there are.
+
+In the registry config file, a new mirror is a dictionary in the `upstream` field:
+
+* `name`: a distinguishable mirror name
+* `urls`: URL template to retrive Julia release
+* `latest_urls`: URL template to retrive the nightly build of Julia release
+
+### Placeholders
+
+Placeholders are used to register new mirrors. For example, the stable release url of
+the "Official" release server provided by [Julialang.org](https://julialang.org/) is
+`"https://julialang-s3.julialang.org/bin/$sys/$arch/$minor_version/$filename"`
+
+There're several predefined placeholders for various systems and architectures:
+
+* `system`: `windows`, `macos`, `linux`, `freebsd`
+* `sys`: `winnt`, `mac`, `linux`, `freebsd`
+* `os`: `win`, `mac`, `linux`, `freebsd`
+* `architecture`: `x86_64`, `i686`, `ARMv7`, `ARMv8`
+* `arch`: `x86`, `x64`, `armv7l`, `aarch64`
+* `osarch`: `win32`, `win64`, `mac64`, `linux-armv7l`, `linux-aarch64`
+* `osbit`: `win32`, `win64`, `linux32`, `linux64`, `linuxaarch64`
+* `bit`: `32`, `64`
+* `extension`: `exe`, `tar.gz`, `dmg` (no leading `.`)
+
+There're also placeholders for versions:
+
+* `patch_version`: `1.2.3`, `latest`
+* `minor_version`: `1.2`, `latest`
+* `major_version`: `1`
+* `version`: `1.2.3-pre`, `latest` (no leading `v`)
+* `vpatch_version`: `v1.2.3`, `latest`
+* `vminor_version`: `v1.2`, `latest`
+* `vmajor_version`: `v1`, `latest`
+
+To keep consistent names with official releases, you can use predefined name placeholders:
+
+* stable release `filename`: `julia-$version-$osarch.$extension`
+* nightly release `latest_filename`: `"julia-latest-$osbit.$extension"`

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fire
 semantic_version
 python-gnupg
 requests_futures
+jsonschema


### PR DESCRIPTION
- [x] cache the downloaded `versions.json` file so that each `jill` call only fetch the data once.
- [x] use `versions-schema.json` to validate the downloaded versions content
- [x] clean up the outdated workflow and imports
- [x] bring back `jill mirror` ~appropriate deprecate `jill mirror` (maybe bring its functionality back)~
- [x] also download `versions.json` from given upstream instead of from the official.
- [x] docs and README

cc: @crstnbr 