### PR TITLE
add `--unstable` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note that `Python >= 3.6` is required. For base docker images, you also need to 
 
 Basic usage:
 
-`jill install [version] [--confirm] [--upstream UPSTREAM] [--reinstall] [--install_dir INSTALL_DIR] [--symlink_dir SYMLINK_DIR]`
+`jill install [version] [--confirm] [--upstream UPSTREAM] [--unstable] [--reinstall] [--install_dir INSTALL_DIR] [--symlink_dir SYMLINK_DIR]`
 
 For the first-time users of `jill.py`, you may need to modify `PATH` accordingly so that your shell can find the executables when you type `julia`.
 
@@ -60,9 +60,9 @@ For the first-time users of `jill.py`, you may need to modify `PATH` accordingly
 
 When you type `jill install` (the simplest usage), it does the following things:
 
-1. query latest stable release, it's `1.4.2` at the time of writing.
-2. download, verify and install julia `1.4.2`
-3. make alias: `julia`, `julia-1`, `julia-1.4`
+1. query latest stable release, it's `1.6.1` at the time of writing.
+2. download, verify and install julia `1.6.1`
+3. make alias: `julia`, `julia-1`, `julia-1.6`
     * for nightly build, it only bind alias to `julia-latest`
 
 Valid `version` syntax:
@@ -72,6 +72,14 @@ Valid `version` syntax:
 - `1.2`: latest stable `1.2.z` release
 - `1.2.3`/`1.2.3-rc1`: as it is
 - `nightly`/`latest`: nightly builds
+
+At the time of writing, "1.6.1" and "1.7.0-beta1" are released, while "1.7.0" isn't yet.
+There are two ways to install an unstable release version `1.7.0-beta1`:
+
+- `jill install 1.7.0-beta1`, as you explicitly requested, installs "1.7.0-beta1" for you.
+- `jill install 1.7 --unstable` will give you the latest 1.7.x version including those unstable ones.
+  Because "1.7.0" is not released yet, it will gives you "1.7.0-beta1". The result may change when
+  more releases are coming. Note that it won't include the "nightly" builds.
 
 Here's a list of slightly advanced usages that you may be interested in:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -41,8 +41,7 @@ _跨平台的 Julia 一键安装脚本_
 
 基本使用:
 
-`jill install [version] [--confirm] [--upstream UPSTREAM] [--reinstall] [--install_dir INSTALL_DIR]
-[--symlink_dir SYMLINK_DIR]`
+`jill install [version] [--confirm] [--upstream UPSTREAM] [--unstable] [--reinstall] [--install_dir INSTALL_DIR] [--symlink_dir SYMLINK_DIR]`
 
 简而言之，`jill install [version]` 能满足你绝大部分要求。对于初次使用 `jill.py` 的用户而言，你可能需要修改 `PATH`
 来让命令行正常找到 Julia.
@@ -54,9 +53,9 @@ _跨平台的 Julia 一键安装脚本_
 
 当你输入 `jill install` 的时候，它其实做了以下几件事:
 
-1. 找到最新的稳定版(目前是`1.4.2`)
+1. 找到最新的稳定版(目前是`1.6.1`)
 2. 下载、验证并安装Julia
-3. 创建一些别名，例如：`julia`, `julia-1`, `julia-1.4`
+3. 创建一些别名，例如：`julia`, `julia-1`, `julia-1.6`
   * 对于每日构建版，别名则只会绑定到 `julia-latest`
 
 其中 `version` 是可选的，支持的语法为：
@@ -66,6 +65,12 @@ _跨平台的 Julia 一键安装脚本_
 - `1.2`: 最新的`1.2.z`稳定版本
 - `1.2.3`/`1.2.3-rc1`: 如其所是
 - `nightly`/`latest`: 每天从源码中构建的版本
+
+目前 "1.6.1" 和 "1.7.0-beta1" 已经发布了， 而 "1.7.0" 还没有。 存在两种方式去安装 `1.7.0-beta1`：
+
+- `jill install 1.7.0-beta1`: 正如你所要求的那样， 会安装 1.7.0-beta1 版本
+- `jill install 1.7 --unstable`: 会安装最新的 "1.7.x" 版本（包括不稳定版本）， 因此在 1.7.0 正式版
+  出来之前都会安装不稳定的 1.7.0 版本. 这个结果随着更多新的版本的发布会随之改变。
 
 除此之外还有一些额外的命令和参数可以使用：
 

--- a/jill/download.py
+++ b/jill/download.py
@@ -50,6 +50,7 @@ def _download(url: str, out: str):
 
 def download_package(version=None, sys=None, arch=None, *,
                      upstream=None,
+                     unstable=False,
                      outdir=None,
                      overwrite=False):
     """
@@ -92,6 +93,11 @@ def download_package(version=None, sys=None, arch=None, *,
       upstream:
         manually choose a download upstream. For example, set it to "Official"
         if you want to download from JuliaComputing's s3 buckets.
+      unstable:
+        add `--unstable` flag to allow installation of unstable releases for auto version
+        query. For example, `jill download --unstable` might give you unstable installation
+        like `1.7.0-beta1`. Note that if you explicitly pass the unstable version, e.g.,
+        `jill download 1.7.0-beta1`, it will still work.
       outdir:
         where release is downloaded to. By default it's the current folder.
       overwrite:
@@ -117,7 +123,7 @@ def download_package(version=None, sys=None, arch=None, *,
     wrong_args = False
     try:
         version = latest_version(
-            version, system, architecture, upstream=upstream)
+            version, system, architecture, upstream=upstream, stable_only=not unstable)
     except ValueError:
         # hide the nested error stack :P
         wrong_args = True

--- a/jill/install.py
+++ b/jill/install.py
@@ -301,6 +301,7 @@ def install_julia(version=None, *,
                   symlink_dir=None,
                   upgrade=False,
                   upstream=None,
+                  unstable=False,
                   keep_downloads=False,
                   confirm=False,
                   reinstall=False):
@@ -314,7 +315,7 @@ def install_julia(version=None, *,
     * `stable`: latest stable Julia release. This is the _default_ option.
     * `1`: latest `1.y.z` Julia release.
     * `1.0`: latest `1.0.z` Julia release.
-    * `1.4.0-rc1`: as it is. This is the only way to install unstable release.
+    * `1.4.0-rc1`: as it is.
     * `latest`/`nightly`: the nightly builds from source code.
 
     For Linux/FreeBSD systems, if you run this command with `root` account,
@@ -331,6 +332,11 @@ def install_julia(version=None, *,
       upgrade:
         add `--upgrade` flag also copy the root environment from an older
         Julia version.
+      unstable:
+        add `--unstable` flag to allow installation of unstable releases for auto version
+        query. For example, `jill install --unstable` might give you unstable installation
+        like `1.7.0-beta1`. Note that if you explicitly pass the unstable version, e.g.,
+        `jill install 1.7.0-beta1`, it will still work.
       keep_downloads:
         add `--keep_downloads` flag to not remove downloaded releases.
       confirm: add `--confirm` flag to skip interactive prompt.
@@ -377,7 +383,7 @@ def install_julia(version=None, *,
     wrong_args = False
     try:
         version = latest_version(
-            version, system, arch, upstream=upstream)
+            version, system, arch, upstream=upstream, stable_only=not unstable)
     except ValueError:
         # hide the nested error stack :P
         wrong_args = True

--- a/jill/utils/version_utils.py
+++ b/jill/utils/version_utils.py
@@ -189,6 +189,7 @@ def latest_version(version: str, system, arch, **kwargs) -> str:
         if len(filtered_compat) == 0:
             latest_ver = max(compat_releases, key=lambda x: Version(x[0]))[0]
             print(f'{color.RED}failed to find latest Julia version for "{version}", "{system}" and "{arch}". Trying latest compatible version "{latest_ver}" instead.{color.END}')
+            print(f'{color.RED}you can add `--unstable` flag to also include unstable releases.{color.END}')
             # This is equivalent to:
             # latest_version('', system, arch, stable_only=stable_only)
             return latest_ver


### PR DESCRIPTION
fixes #54 by passing `stable_only` keyword to `latest_version`

In jill v0.9 series, `jill install` will bring us unstable releases by default because we changed the version query mechanism:

```bash
➜ jill install
JILL - Julia Installer 4 Linux (MacOS, Windows and FreeBSD) -- Light

jill will:
  1) install Julia latest stable release for mac-x86_64 into /Applications
  2) make symlinks in /Users/jc/.local/bin
You may need to manually add /Users/jc/.local/bin to PATH
Continue installation? [Y/n]
querying release information from https://mirrors.ustc.edu.cn/julia-releases/bin/versions.json
----- Download Julia -----
downloading Julia release for 1.7.0-beta1-mac-x86_64
```

This PR fixes it. `1.7.0-beta1` will only get installed when requested explicitly:

```bash
jill install --unstable
jill install 1 --unstable
jill install 1.7 --unstable
jill install 1.7.0-beta1
```

---

For unstable releases: `alpha`<`beta`<`rc`. If new rc versions come out, it will install rc versions:

```python
from semantic_version import Version
sorted([Version("1.7.0-alpha1"), Version("1.7.0-alpha2"), Version("1.7.0-beta1"), Version("1.7.0-beta2"), Version("1.7.0-rc1"), Version("1.7.0-rc2"), Version("1.7.0")])

Out[9]: 
[Version('1.7.0-alpha1'),
 Version('1.7.0-alpha2'),
 Version('1.7.0-beta1'),
 Version('1.7.0-beta2'),
 Version('1.7.0-rc1'),
 Version('1.7.0-rc2'),
 Version('1.7.0')]
```

Tests are not added because it's too "unstable".