### PR TITLE
update versions-schema and fix fallback solution

### DIFF
--- a/jill/config/versions-schema.json
+++ b/jill/config/versions-schema.json
@@ -120,7 +120,8 @@
                 "aarch64-linux-gnu",
                 "armv7l-linux-gnueabihf",
                 "x86_64-unknown-freebsd11.1",
-                "x86_64-linux-musl"
+                "x86_64-linux-musl",
+                "aarch64-apple-darwin14"
             ],
             "title": "Triplet"
         }

--- a/jill/utils/version_utils.py
+++ b/jill/utils/version_utils.py
@@ -100,7 +100,7 @@ def read_remote_versions(upstream, cache=dict()):
             is_valid = False
             print(
                 f'{color.YELLOW} failed to validate versions file, retry with latest schema...')
-            schema = json.load(requests.get(VERSIONS_SCHEMA_URL).text)
+            schema = requests.get(VERSIONS_SCHEMA_URL).json()
         if not is_valid:
             jsonschema.validate(version_list, schema)
 


### PR DESCRIPTION
With mac M1 added upstream, the old versions-schema gets outdated, and it immediately hit a json parsing bug in our fallback solution.

```julia
 failed to validate versions file, retry with latest schema...
Traceback (most recent call last):
  File "/Users/jc/local/anaconda3/lib/python3.8/site-packages/jill/utils/version_utils.py", line 97, in read_remote_versions
    jsonschema.validate(version_list, schema)
  File "/Users/jc/local/anaconda3/lib/python3.8/site-packages/jsonschema/validators.py", line 934, in validate
    raise error
jsonschema.exceptions.ValidationError: 'aarch64-apple-darwin14' is not one of ['x86_64-apple-darwin14', 'x86_64-w64-mingw32', 'i686-w64-mingw32', 'x86_64-linux-gnu', 'i686-linux-gnu', 'powerpc64le-linux-gnu', 'aarch64-linux-gnu', 'armv7l-linux-gnueabihf', 'x86_64-unknown-freebsd11.1', 'x86_64-linux-musl']

Failed validating 'enum' in schema['additionalProperties']['properties']['files']['items']['properties']['triplet']:
    {'enum': ['x86_64-apple-darwin14',
              'x86_64-w64-mingw32',
              'i686-w64-mingw32',
              'x86_64-linux-gnu',
              'i686-linux-gnu',
              'powerpc64le-linux-gnu',
              'aarch64-linux-gnu',
              'armv7l-linux-gnueabihf',
              'x86_64-unknown-freebsd11.1',
              'x86_64-linux-musl'],
     'title': 'Triplet',
     'type': 'string'}

On instance['1.7.0-beta3']['files'][5]['triplet']:
    'aarch64-apple-darwin14'

During handling of the above exception, another exception occurred:
```

Will merge and tag a new patch release once test passes.