### PR TITLE
fix SSL: CERTIFICATE_VERIFY_FAILED (failed to download )

### DIFF
--- a/jill/download.py
+++ b/jill/download.py
@@ -13,12 +13,15 @@ import os
 import shutil
 import tempfile
 import logging
+import traceback
 
 from urllib.parse import urlparse
 
 from typing import Optional
 
 from urllib.error import URLError
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
 
 
 def _download(url: str, out: str):
@@ -40,6 +43,7 @@ def _download(url: str, out: str):
             msg = f"failed to download {outname}"
             logging.info(msg)
             print(f"{color.RED}{msg}{color.END}")
+            traceback.print_exc()
             return False
 
         if not os.path.isdir(outdir):


### PR DESCRIPTION
0. this commit fix problem followed

1. problem:   SSL: CERTIFICATE_VERIFY_FAILED     




2. problem occur: 
python version : Python 3.8.5
os : ms window 10 x64

%windir%\System32\cmd.exe "/K" d:\Miniconda3_py38\Scripts\activate.bat d:\Miniconda3_py38

execute : pip install jill

execute : jill install 1.6.5
get error :

[1mJILL - Julia Installer 4 Linux (MacOS, Windows and FreeBSD) -- Light [0m

jill will:

install Julia 1.6.5 for winnt-x86_64 into �[4mC:\Users\enmonster\AppData\Local\julias�[0m
make symlinks in �[4mC:\Users\enmonster\AppData\Local\julias\bin�[0m
You may need to manually add �[4mC:\Users\enmonster\AppData\Local\julias\bin�[0m to PATH
Continue installation? [Y/n] y
�[1m----- Download Julia -----�[0m
downloading Julia release for 1.6.5-winnt-x86_64
downloading from https://mirrors.sjtug.sjtu.edu.cn/julia-releases/bin/winnt/x64/1.6/julia-1.6.5-win64.exe
�[91mfailed to download julia-1.6.5-win64.exe�[0m
Traceback (most recent call last):
File "d:\miniconda3_py38\lib\urllib\request.py", line 1350, in do_open
h.request(req.get_method(), req.selector, req.data, headers,
File "d:\miniconda3_py38\lib\http\client.py", line 1255, in request
self._send_request(method, url, body, headers, encode_chunked)
File "d:\miniconda3_py38\lib\http\client.py", line 1301, in _send_request
self.endheaders(body, encode_chunked=encode_chunked)
File "d:\miniconda3_py38\lib\http\client.py", line 1250, in endheaders
self._send_output(message_body, encode_chunked=encode_chunked)
File "d:\miniconda3_py38\lib\http\client.py", line 1010, in _send_output
self.send(msg)
File "d:\miniconda3_py38\lib\http\client.py", line 950, in send
self.connect()
File "d:\miniconda3_py38\lib\http\client.py", line 1424, in connect
self.sock = self._context.wrap_socket(self.sock,
File "d:\miniconda3_py38\lib\ssl.py", line 500, in wrap_socket
return self.sslsocket_class._create(
File "d:\miniconda3_py38\lib\ssl.py", line 1040, in _create
self.do_handshake()
File "d:\miniconda3_py38\lib\ssl.py", line 1309, in do_handshake
self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: certificate has expired (_ssl.c:1123)
During handling of the above exception, another exception occurred: